### PR TITLE
Fixup executors

### DIFF
--- a/ros_middleware_opensplice_cpp/src/functions.cpp
+++ b/ros_middleware_opensplice_cpp/src/functions.cpp
@@ -369,6 +369,8 @@ void wait(ros_middleware_interface::SubscriberHandles& subscriber_handles, ros_m
     {
       if (active_conditions[j] == condition)
       {
+        DDS::GuardCondition *guard = (DDS::GuardCondition*)data;
+        guard->set_trigger_value(false);
         break;
       }
     }


### PR DESCRIPTION
Fixes a few things I found while developing executors:
- Print implementation type (opensplice) during node creation
- Check for and prevent topics with `/` in the name
- Reset guard conditions after they have been found to be active
