### PR TITLE
opensplice_cmake_module: workaround for os x

### DIFF
--- a/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
+++ b/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
@@ -67,7 +67,7 @@ if(NOT "${_ospl_home}" STREQUAL "")
   set(OpenSplice_FOUND TRUE)
 else()
   # try to find_package() it
-  find_package(opensplice REQUIRED COMPONENTS CXX)
+  find_package(opensplice NO_MODULE REQUIRED COMPONENTS CXX PATHS /usr /usr/local)
   if(OPENSPLICE_FOUND)
     message(STATUS "Found PrismTech OpenSplice: ${opensplice_DIR}")
     set(OpenSplice_HOME "${OPENSPLICE_PREFIX}")


### PR DESCRIPTION
The filesystem is case insensitive, so it creates an infinite loop until cmake segfaults. This works around this by removing this module's directory from the `CMAKE_MODULE_PATH` before looking for the other module shipped with our opensplice package. I then restore it. I think this is safe since the path will be `<prefix>/share/opensplice_cmake_module/cmake` and so it shouldn't contain any other modules.
