### PR TITLE
Unify callback structures

### DIFF
--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -8,6 +8,7 @@
 #include <rmw/rmw.h>
 #include <rosidl_generator_c/message_type_support.h>
 #include <rosidl_typesupport_opensplice_cpp/message_type_support.h>
+#include <rosidl_typesupport_opensplice_cpp/service_type_support.h>
 
 // The extern "C" here enforces that overloading is not used.
 extern "C"
@@ -20,6 +21,18 @@ rmw_get_implementation_identifier()
 {
   return opensplice_cpp_identifier;
 }
+
+struct OpenSpliceStaticSubscriberInfo
+{
+  DDS::DataReader * topic_reader;
+  const message_type_support_callbacks_t * callbacks;
+};
+
+struct OpenSpliceStaticPublisherInfo
+{
+  DDS::DataWriter * topic_writer;
+  const message_type_support_callbacks_t * callbacks;
+};
 
 rmw_ret_t
 rmw_init()
@@ -81,12 +94,6 @@ rmw_destroy_node(rmw_node_t * node)
   rmw_node_free(node);
   return RMW_RET_OK;
 }
-
-struct OpenSpliceStaticPublisherInfo
-{
-  DDS::DataWriter * topic_writer;
-  const message_type_support_callbacks_t * callbacks;
-};
 
 rmw_publisher_t *
 rmw_create_publisher(const rmw_node_t * node,
@@ -224,12 +231,6 @@ rmw_publish(const rmw_publisher_t * publisher, const void * ros_message)
   callbacks->publish(topic_writer, ros_message);
   return RMW_RET_OK;
 }
-
-struct OpenSpliceStaticSubscriberInfo
-{
-  DDS::DataReader * topic_reader;
-  const message_type_support_callbacks_t * callbacks;
-};
 
 rmw_subscription_t *
 rmw_create_subscription(const rmw_node_t * node,

--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -22,15 +22,15 @@ rmw_get_implementation_identifier()
   return opensplice_cpp_identifier;
 }
 
-struct OpenSpliceStaticSubscriberInfo
-{
-  DDS::DataReader * topic_reader;
-  const message_type_support_callbacks_t * callbacks;
-};
-
 struct OpenSpliceStaticPublisherInfo
 {
   DDS::DataWriter * topic_writer;
+  const message_type_support_callbacks_t * callbacks;
+};
+
+struct OpenSpliceStaticSubscriberInfo
+{
+  DDS::DataReader * topic_reader;
   const message_type_support_callbacks_t * callbacks;
 };
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/MessageTypeSupport.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/MessageTypeSupport.h
@@ -19,14 +19,6 @@ extern const char * _prismtech_opensplice_identifier;
 namespace rmw_opensplice_cpp
 {
 
-typedef struct MessageTypeSupportCallbacks {
-  const char * _package_name;
-  const char * _message_name;
-  void (*_register_type)(DDS::DomainParticipant * participant, const char * type_name);
-  void (*_publish)(DDS::DataWriter * topic_writer, const void * ros_message);
-  bool (*_take)(DDS::DataReader * topic_reader, void * ros_message);
-} MessageTypeSupportCallbacks;
-
 template<typename T>
 const rosidl_message_type_support_t * get_type_support_handle();
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/ServiceTypeSupport.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/ServiceTypeSupport.h
@@ -6,6 +6,8 @@
 
 namespace DDS {
 class DomainParticipant;
+class DataReader;
+class DataWriter;
 }
 
 namespace rmw
@@ -17,13 +19,6 @@ extern const char * _prismtech_opensplice_identifier;
 
 namespace rmw_opensplice_cpp
 {
-
-typedef struct ServiceTypeSupportCallbacks {
-  const char * _package_name;
-  const char * _message_name;
-  void* (*_create_client)(DDS::DomainParticipant * participant, const char * service_name);
-  void* (*_create_service)(DDS::DomainParticipant * participant, const char * service_name);
-} ServiceTypeSupportCallbacks;
 
 template<typename T>
 const rosidl_service_type_support_t * get_service_type_support_handle();

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
@@ -1,0 +1,12 @@
+#ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_SERVICE_TYPE_SUPPORT_H_
+#define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_SERVICE_TYPE_SUPPORT_H_
+
+#include "rosidl_generator_c/service_type_support.h"
+
+typedef struct service_type_support_callbacks_t
+{
+  const char * package_name;
+  const char * service_name;
+} service_type_support_callbacks_t;
+
+#endif  /* ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_SERVICE_TYPE_SUPPORT_H_ */

--- a/rosidl_typesupport_opensplice_cpp/resource/msg_TypeSupport.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg_TypeSupport.cpp.template
@@ -16,8 +16,8 @@
 
 #include "@(spec.base_type.pkg_name)/@(spec.base_type.type)_Struct.h"
 #include "@(spec.base_type.pkg_name)/dds_opensplice/ccpp_@(spec.base_type.type)_.h"
-#include "rosidl_generator_cpp/MessageTypeSupport.h"
-#include "rosidl_typesupport_opensplice_cpp/MessageTypeSupport.h"
+#include <rosidl_typesupport_opensplice_cpp/message_type_support.h>
+#include <rosidl_typesupport_opensplice_cpp/MessageTypeSupport.h>
 #include "rmw/get_type_support_handle.h"
 
 @[for field in spec.fields]@
@@ -45,8 +45,9 @@ namespace @(spec.base_type.pkg_name)
 namespace type_support
 {
 
-void register_type__@(spec.base_type.type)(DDS::DomainParticipant * participant, const char * type_name)
+void register_type__@(spec.base_type.type)(void * untyped_participant, const char * type_name)
 {
+    DDS::DomainParticipant * participant = static_cast<DDS::DomainParticipant *>(untyped_participant);
     std::cout << "  @(spec.base_type.pkg_name)::type_support::register_type__@(spec.base_type.type)()" << std::endl;
     @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_TypeSupport * ros_message_ts = new @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_TypeSupport();
     DDS::ReturnCode_t status = ros_message_ts->register_type(participant, type_name);
@@ -100,8 +101,9 @@ void convert_ros_message_to_dds(const @(spec.base_type.pkg_name)::@(spec.base_ty
 @[end for]@
 }
 
-void publish__@(spec.base_type.type)(DDS::DataWriter * topic_writer, const void * untyped_ros_message)
+void publish__@(spec.base_type.type)(void * untyped_topic_writer, const void * untyped_ros_message)
 {
+    DDS::DataWriter * topic_writer = static_cast<DDS::DataWriter *>(untyped_topic_writer);
     //std::cout << "  @(spec.base_type.pkg_name)::type_support::publish__@(spec.base_type.type)()" << std::endl;
 
     const @(spec.base_type.pkg_name)::@(spec.base_type.type) & ros_message = *(const @(spec.base_type.pkg_name)::@(spec.base_type.type) *)untyped_ros_message;
@@ -160,8 +162,9 @@ void convert_dds_message_to_ros(const @(spec.base_type.pkg_name)::dds_::@(spec.b
 @[end for]@
 }
 
-bool take__@(spec.base_type.type)(DDS::DataReader * topic_reader, void * untyped_ros_message)
+bool take__@(spec.base_type.type)(void * untyped_topic_reader, void * untyped_ros_message)
 {
+    DDS::DataReader * topic_reader = static_cast<DDS::DataReader *>(untyped_topic_reader);
     //std::cout << "  @(spec.base_type.pkg_name)::type_support::publish__@(spec.base_type.type)()" << std::endl;
 
     @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader * data_reader = @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader::_narrow(topic_reader);
@@ -198,7 +201,7 @@ bool take__@(spec.base_type.type)(DDS::DataReader * topic_reader, void * untyped
     return true;
 }
 
-static rmw_opensplice_cpp::MessageTypeSupportCallbacks callbacks = {
+static message_type_support_callbacks_t callbacks = {
     "@(spec.base_type.pkg_name)",
     "@(spec.base_type.type)",
     &register_type__@(spec.base_type.type),

--- a/rosidl_typesupport_opensplice_cpp/resource/srv_ServiceTypeSupport.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv_ServiceTypeSupport.cpp.template
@@ -18,6 +18,7 @@
 #include "@(spec.pkg_name)/@(spec.srv_name)_Service.h"
 #include "rosidl_generator_cpp/ServiceTypeSupport.h"
 #include "rosidl_typesupport_opensplice_cpp/ServiceTypeSupport.h"
+#include "rosidl_typesupport_opensplice_cpp/service_type_support.h"
 
 namespace @(spec.pkg_name)
 {
@@ -25,15 +26,9 @@ namespace @(spec.pkg_name)
 namespace service_type_support
 {
 
-void * create_client__@(spec.srv_name)(DDS::DomainParticipant * participant, const char * service_name)
-{
-  return NULL;
-}
-
-static rmw_opensplice_cpp::ServiceTypeSupportCallbacks callbacks = {
+static service_type_support_callbacks_t callbacks = {
     "@(spec.pkg_name)",
     "@(spec.srv_name)",
-    &create_client__@(spec.srv_name),
 };
 
 static rosidl_service_type_support_t handle = {


### PR DESCRIPTION
This branch removes the C++ callbacks structures and uses the plain C message_type_support_callbacks_t and service_type_support_callbacks_t

This is analogous to ros2/rmw_connext#6

@dirk-thomas @tfoote @wjwwood