### PR TITLE
remove exporting non-existing include dir

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rosidl_typesupport_opensplice_cpp REQUIRED)
 
 ament_export_definitions(${OpenSplice_DEFINITIONS})
 ament_export_dependencies(rmw rosidl_generator_cpp rosidl_typesupport_opensplice_cpp)
-ament_export_include_directories(include/${PROJECT_NAME}/impl ${OpenSplice_INCLUDE_DIRS})
+ament_export_include_directories(${OpenSplice_INCLUDE_DIRS})
 
 link_directories(${OpenSplice_LIBRARY_DIRS})
 add_library(rmw_opensplice_cpp SHARED src/functions.cpp)


### PR DESCRIPTION
Currently it results in a CMake warning when this package is being `find_package()-ed`.

@esteve @tfoote @wjwwood Please review.