### PR TITLE
Do not generate IDL files for .srv files for OpenSplice

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -6,9 +6,18 @@ message("   - dependency package names: ${rosidl_generate_interfaces_DEPENDENCY_
 # avoid generating any opensplice specific stuff for builtin_msgs
 if(NOT "${PROJECT_NAME} " STREQUAL "builtin_msgs ")
 
+set(_ros_idl_files "")
+foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  # Skip .srv files
+  if("${_extension}" STREQUAL ".msg")
+    list(APPEND _ros_idl_files "${_idl_file}")
+  endif()
+endforeach()
+
 rosidl_generate_dds_interfaces(
   ${rosidl_generate_interfaces_TARGET}__dds_opensplice_idl
-  IDL_FILES ${rosidl_generate_interfaces_IDL_FILES}
+  IDL_FILES ${_ros_idl_files}
   DEPENDENCY_PACKAGE_NAMES ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES}
   OUTPUT_SUBFOLDERS "dds_opensplice"
   EXTENSION "rosidl_typesupport_opensplice_cpp.rosidl_generator_dds_idl_extension"


### PR DESCRIPTION
This branch generates DDS types for requests and responses, without generating extra ROS types.

These changes are temporary so that ros2/rosidl_dds#7 can be merged

Connects to ros2/rmw_opensplice#10

@dirk-thomas @tfoote @wjwwood 