### PR TITLE
Use plain pointer types instead of _ptr

### DIFF
--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -19,25 +19,25 @@ RMW_PUBLIC const char * opensplice_cpp_identifier = "opensplice_static";
 
 struct OpenSpliceStaticPublisherInfo
 {
-  DDS::DataWriter_ptr topic_writer;
+  DDS::DataWriter* topic_writer;
   const message_type_support_callbacks_t * callbacks;
 };
 
 struct OpenSpliceStaticSubscriberInfo
 {
-  DDS::DataReader_ptr topic_reader;
+  DDS::DataReader* topic_reader;
   const message_type_support_callbacks_t * callbacks;
 };
 
 struct OpenSpliceStaticClientInfo {
   void * requester_;
-  DDS::DataReader_ptr response_datareader_;
+  DDS::DataReader* response_datareader_;
   const service_type_support_callbacks_t * callbacks_;
 };
 
 struct OpenSpliceStaticServiceInfo {
   void * responder_;
-  DDS::DataReader_ptr request_datareader_;
+  DDS::DataReader* request_datareader_;
   const service_type_support_callbacks_t * callbacks_;
 };
 
@@ -74,7 +74,7 @@ rmw_create_node(const char * name)
   // TODO: take the domain id from configuration
   DDS::DomainId_t domain = 0;
 
-  DDS::DomainParticipant_ptr participant = dp_factory->create_participant(
+  DDS::DomainParticipant* participant = dp_factory->create_participant(
     domain, PARTICIPANT_QOS_DEFAULT, NULL, DDS::STATUS_MASK_NONE
   );
   if (!participant)
@@ -122,8 +122,8 @@ rmw_create_publisher(const rmw_node_t * node,
     return nullptr;
   }
 
-  DDS::DomainParticipant_ptr participant = \
-    static_cast<DDS::DomainParticipant_ptr>(node->data);
+  DDS::DomainParticipant* participant = \
+    static_cast<DDS::DomainParticipant*>(node->data);
 
   const message_type_support_callbacks_t * callbacks = \
     static_cast<const message_type_support_callbacks_t *>(type_support->data);
@@ -185,7 +185,7 @@ rmw_create_publisher(const rmw_node_t * node,
     return nullptr;
   };
 
-  DDS::DataWriter_ptr topic_writer = dds_publisher->create_datawriter(
+  DDS::DataWriter* topic_writer = dds_publisher->create_datawriter(
     topic, default_datawriter_qos, NULL, DDS::STATUS_MASK_NONE
   );
   if (!topic_writer)
@@ -237,7 +237,7 @@ rmw_publish(const rmw_publisher_t * publisher, const void * ros_message)
 
   const OpenSpliceStaticPublisherInfo * publisher_info = \
     static_cast<const OpenSpliceStaticPublisherInfo *>(publisher->data);
-  DDS::DataWriter_ptr topic_writer = publisher_info->topic_writer;
+  DDS::DataWriter* topic_writer = publisher_info->topic_writer;
   const message_type_support_callbacks_t * callbacks = \
     publisher_info->callbacks;
 
@@ -257,8 +257,8 @@ rmw_create_subscription(const rmw_node_t * node,
     return nullptr;
   }
 
-  DDS::DomainParticipant_ptr participant = \
-    static_cast<DDS::DomainParticipant_ptr>(node->data);
+  DDS::DomainParticipant* participant = \
+    static_cast<DDS::DomainParticipant*>(node->data);
 
   const message_type_support_callbacks_t * callbacks = \
     static_cast<const message_type_support_callbacks_t *>(type_support->data);
@@ -316,7 +316,7 @@ rmw_create_subscription(const rmw_node_t * node,
     return nullptr;
   }
 
-  DDS::DataReader_ptr topic_reader = dds_subscriber->create_datareader(
+  DDS::DataReader* topic_reader = dds_subscriber->create_datareader(
     topic, default_datareader_qos, NULL, DDS::STATUS_MASK_NONE
   );
 
@@ -367,7 +367,7 @@ rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * tak
 
   OpenSpliceStaticSubscriberInfo * subscriber_info = \
     static_cast<OpenSpliceStaticSubscriberInfo *>(subscription->data);
-  DDS::DataReader_ptr topic_reader = subscriber_info->topic_reader;
+  DDS::DataReader* topic_reader = subscriber_info->topic_reader;
   const message_type_support_callbacks_t * callbacks = \
     subscriber_info->callbacks;
 
@@ -381,7 +381,7 @@ rmw_create_guard_condition()
 {
   rmw_guard_condition_t * guard_condition = rmw_guard_condition_allocate();
   guard_condition->implementation_identifier = opensplice_cpp_identifier;
-  guard_condition->data = static_cast<DDS::GuardCondition_ptr>(
+  guard_condition->data = static_cast<DDS::GuardCondition*>(
     rmw_allocate(sizeof(DDS::GuardCondition)));
   // Ensure constructor with "placement new"
   new (guard_condition->data) DDS::GuardCondition();
@@ -416,8 +416,8 @@ rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition)
     return RMW_RET_ERROR;
   }
 
-  DDS::GuardCondition_ptr dds_guard_condition = \
-    static_cast<DDS::GuardCondition_ptr>(guard_condition->data);
+  DDS::GuardCondition* dds_guard_condition = \
+    static_cast<DDS::GuardCondition*>(guard_condition->data);
   dds_guard_condition->set_trigger_value(true);
   return RMW_RET_OK;
 }
@@ -438,8 +438,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
     OpenSpliceStaticSubscriberInfo * subscriber_info = \
       static_cast<OpenSpliceStaticSubscriberInfo *>(
         subscriptions->subscribers[i]);
-    DDS::DataReader_ptr topic_reader = subscriber_info->topic_reader;
-    DDS::StatusCondition_ptr condition = topic_reader->get_statuscondition();
+    DDS::DataReader* topic_reader = subscriber_info->topic_reader;
+    DDS::StatusCondition* condition = topic_reader->get_statuscondition();
     condition->set_enabled_statuses(DDS::DATA_AVAILABLE_STATUS);
     waitset.attach_condition(condition);
   }
@@ -447,8 +447,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   // add a condition for each guard condition
   for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i)
   {
-    DDS::GuardCondition_ptr guard_condition = \
-      static_cast<DDS::GuardCondition_ptr>(
+    DDS::GuardCondition* guard_condition = \
+      static_cast<DDS::GuardCondition*>(
         guard_conditions->guard_conditions[i]);
     waitset.attach_condition(guard_condition);
   }
@@ -458,8 +458,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   {
     OpenSpliceStaticServiceInfo * service_info = \
       static_cast<OpenSpliceStaticServiceInfo *>(services->services[i]);
-    DDS::DataReader_ptr request_datareader = service_info->request_datareader_;
-    DDS::StatusCondition_ptr condition = request_datareader->get_statuscondition();
+    DDS::DataReader* request_datareader = service_info->request_datareader_;
+    DDS::StatusCondition* condition = request_datareader->get_statuscondition();
     condition->set_enabled_statuses(DDS::DATA_AVAILABLE_STATUS);
     waitset.attach_condition(condition);
   }
@@ -469,8 +469,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   {
     OpenSpliceStaticClientInfo * client_info = \
       static_cast<OpenSpliceStaticClientInfo *>(clients->clients[i]);
-    DDS::DataReader_ptr response_datareader = client_info->response_datareader_;
-    DDS::StatusCondition_ptr condition = response_datareader->get_statuscondition();
+    DDS::DataReader* response_datareader = client_info->response_datareader_;
+    DDS::StatusCondition* condition = response_datareader->get_statuscondition();
     condition->set_enabled_statuses(DDS::DATA_AVAILABLE_STATUS);
     waitset.attach_condition(condition);
   }
@@ -506,8 +506,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
     OpenSpliceStaticSubscriberInfo * subscriber_info = \
       static_cast<OpenSpliceStaticSubscriberInfo *>(
         subscriptions->subscribers[i]);
-    DDS::DataReader_ptr topic_reader = subscriber_info->topic_reader;
-    DDS::StatusCondition_ptr condition = topic_reader->get_statuscondition();
+    DDS::DataReader* topic_reader = subscriber_info->topic_reader;
+    DDS::StatusCondition* condition = topic_reader->get_statuscondition();
     if (!condition->get_trigger_value())
     {
       // if the status condition was not triggered
@@ -519,8 +519,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   // set guard condition handles to zero for all not triggered guard conditions
   for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i)
   {
-    DDS::GuardCondition_ptr guard_condition = \
-      static_cast<DDS::GuardCondition_ptr>(
+    DDS::GuardCondition* guard_condition = \
+      static_cast<DDS::GuardCondition*>(
         guard_conditions->guard_conditions[i]);
     if (!guard_condition->get_trigger_value())
     {
@@ -540,8 +540,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   {
     OpenSpliceStaticServiceInfo * service_info = \
       static_cast<OpenSpliceStaticServiceInfo *>(services->services[i]);
-    DDS::DataReader_ptr request_datareader = service_info->request_datareader_;
-    DDS::StatusCondition_ptr condition = request_datareader->get_statuscondition();
+    DDS::DataReader* request_datareader = service_info->request_datareader_;
+    DDS::StatusCondition* condition = request_datareader->get_statuscondition();
 
     // search for service condition in active set
     unsigned long j = 0;
@@ -565,8 +565,8 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   {
     OpenSpliceStaticClientInfo * client_info = \
       static_cast<OpenSpliceStaticClientInfo *>(clients->clients[i]);
-    DDS::DataReader_ptr response_datareader = client_info->response_datareader_;
-    DDS::StatusCondition_ptr condition = response_datareader->get_statuscondition();
+    DDS::DataReader* response_datareader = client_info->response_datareader_;
+    DDS::StatusCondition* condition = response_datareader->get_statuscondition();
 
     // search for service condition in active set
     unsigned long j = 0;
@@ -600,13 +600,13 @@ rmw_create_client(const rmw_node_t * node,
     return NULL;
   }
 
-  DDS::DomainParticipant_ptr participant = \
-    static_cast<DDS::DomainParticipant_ptr>(node->data);
+  DDS::DomainParticipant* participant = \
+    static_cast<DDS::DomainParticipant*>(node->data);
 
   const service_type_support_callbacks_t * callbacks = \
     static_cast<const service_type_support_callbacks_t *>(type_support->data);
 
-  DDS::DataReader_ptr response_datareader = NULL;
+  DDS::DataReader* response_datareader = NULL;
   void * requester = NULL;
 
   callbacks->create_requester(
@@ -698,12 +698,12 @@ rmw_create_service(const rmw_node_t * node,
       return NULL;
   }
 
-  DDS::DomainParticipant_ptr participant = static_cast<DDS::DomainParticipant_ptr>(node->data);
+  DDS::DomainParticipant* participant = static_cast<DDS::DomainParticipant*>(node->data);
 
   const service_type_support_callbacks_t * callbacks = \
     static_cast<const service_type_support_callbacks_t *>(type_support->data);
 
-  DDS::DataReader_ptr request_datareader = NULL;
+  DDS::DataReader* request_datareader = NULL;
   void * responder = NULL;
 
   callbacks->create_responder(

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
@@ -32,7 +32,7 @@ template<typename RequestT, typename ResponseT>
 class Requester
 {
   public:
-    Requester(DDS::DomainParticipant_ptr participant, const std::string& service_name,
+    Requester(DDS::DomainParticipant* participant, const std::string& service_name,
               const std::string& service_type_name) :
       participant_(participant), service_name_(service_name),
       service_type_name_(service_type_name), sequence_number_(0)
@@ -135,22 +135,22 @@ class Requester
       TemplateDataWriter< Sample<RequestT> >::write_sample(request_datawriter_, request);
     }
 
-    DDS::DataReader_ptr get_response_datareader()
+    DDS::DataReader* get_response_datareader()
     {
       return response_datareader_;
     }
 
   private:
-    DDS::DomainParticipant_ptr participant_;
+    DDS::DomainParticipant* participant_;
     std::string service_name_;
     std::string service_type_name_;
-    DDS::DataReader_ptr response_datareader_;
-    DDS::DataWriter_ptr request_datawriter_;
-    DDS::Topic_ptr response_topic_;
-    DDS::ContentFilteredTopic_ptr content_filtered_response_topic_;
-    DDS::Topic_ptr request_topic_;
-    DDS::Subscriber_ptr response_subscriber_;
-    DDS::Publisher_ptr request_publisher_;
+    DDS::DataReader* response_datareader_;
+    DDS::DataWriter* request_datawriter_;
+    DDS::Topic* response_topic_;
+    DDS::ContentFilteredTopic* content_filtered_response_topic_;
+    DDS::Topic* request_topic_;
+    DDS::Subscriber* response_subscriber_;
+    DDS::Publisher* request_publisher_;
     std::atomic<int64_t> sequence_number_;
     std::pair<uint64_t, uint64_t> writer_guid_;
 };

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -30,7 +30,7 @@ class Responder
 {
   public:
 
-    Responder(DDS::DomainParticipant_ptr participant, const std::string& service_name,
+    Responder(DDS::DomainParticipant* participant, const std::string& service_name,
       const std::string& service_type_name) : participant_(participant),
       service_name_(service_name), service_type_name_(service_type_name)
     {
@@ -121,15 +121,15 @@ class Responder
 
   private:
 
-    DDS::DomainParticipant_ptr participant_;
+    DDS::DomainParticipant* participant_;
     std::string service_name_;
     std::string service_type_name_;
-    DDS::DataReader_ptr request_datareader_;
-    DDS::Topic_ptr request_topic_;
-    DDS::Subscriber_ptr request_subscriber_;
-    DDS::DataWriter_ptr response_datawriter_;
-    DDS::Publisher_ptr response_publisher_;
-    DDS::Topic_ptr response_topic_;
+    DDS::DataReader* request_datareader_;
+    DDS::Topic* request_topic_;
+    DDS::Subscriber* request_subscriber_;
+    DDS::DataWriter* response_datawriter_;
+    DDS::Publisher* response_publisher_;
+    DDS::Topic* response_topic_;
 };
 
 }  // namespace rosidl_typesupport_opensplice_cpp

--- a/rosidl_typesupport_opensplice_cpp/resource/msg_TypeSupport.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg_TypeSupport.cpp.template
@@ -172,10 +172,10 @@ void convert_dds_message_to_ros(const @(spec.base_type.pkg_name)::dds_::@(spec.b
 
 bool take__@(spec.base_type.type)(void * untyped_topic_reader, void * untyped_ros_message)
 {
-    DDS::DataReader_ptr topic_reader = static_cast<DDS::DataReader_ptr>(untyped_topic_reader);
+    DDS::DataReader* topic_reader = static_cast<DDS::DataReader*>(untyped_topic_reader);
     //std::cout << "  @(spec.base_type.pkg_name)::type_support::publish__@(spec.base_type.type)()" << std::endl;
 
-    @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader_ptr data_reader = @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader::_narrow(topic_reader);
+    @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader* data_reader = @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_DataReader::_narrow(topic_reader);
     //std::cout << "  @(spec.base_type.pkg_name)::type_support::publish__@(spec.base_type.type)() write dds message" << std::endl;
 
     @(spec.base_type.pkg_name)::dds_::@(spec.base_type.type)_Seq dds_messages;

--- a/rosidl_typesupport_opensplice_cpp/resource/srv_ServiceTypeSupport.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv_ServiceTypeSupport.cpp.template
@@ -77,9 +77,9 @@ template <>
 class TemplateDataReader<@(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_> : public @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataReader
 {
   public:
-    static bool take_sample(DDS::DataReader_ptr datareader,
+    static bool take_sample(DDS::DataReader* datareader,
                             Sample<@(spec.pkg_name)::dds_::@(spec.srv_name)@(suffix)_>& sample) {
-      @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataReader_ptr typed_datareader = _narrow(datareader);
+      @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataReader* typed_datareader = _narrow(datareader);
 
       @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_Seq dds_messages;
       DDS::SampleInfoSeq sample_infos;
@@ -115,9 +115,9 @@ class TemplateDataReader<Sample<@(spec.pkg_name)::dds_::@(spec.srv_name)@(suffix
 template <>
 class TemplateDataWriter<@(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_> : public @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataWriter {
   public:
-    static void write_sample(DDS::DataWriter_ptr datawriter,
+    static void write_sample(DDS::DataWriter* datawriter,
                              Sample<@(spec.pkg_name)::dds_::@(spec.srv_name)@(suffix)_>& sample) {
-      @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataWriter_ptr typed_datawriter = _narrow(datawriter);
+      @(spec.pkg_name)::dds_::Sample@(spec.srv_name)@(suffix)_DataWriter* typed_datawriter = _narrow(datawriter);
 
       typed_datawriter->write(sample, DDS::HANDLE_NIL);
     }
@@ -142,7 +142,7 @@ void register_types__@(spec.srv_name)(
   void * untyped_participant, const char * request_type_name,
   const char * response_type_name)
 {
-  DDS::DomainParticipant_ptr participant = static_cast<DDS::DomainParticipant_ptr>(untyped_participant);
+  DDS::DomainParticipant* participant = static_cast<DDS::DomainParticipant*>(untyped_participant);
 
   std::cout << "  @(spec.pkg_name)::type_support::register_type__@(spec.srv_name)()" << std::endl;
 
@@ -173,8 +173,8 @@ void create_requester__@(spec.srv_name)(void * untyped_participant, const char *
   const std::string request_type_name("@(spec.pkg_name)::dds_::Sample@(spec.srv_name)Request_");
   const std::string response_type_name("@(spec.pkg_name)::dds_::Sample@(spec.srv_name)Response_");
 
-  DDS::DomainParticipant_ptr participant = static_cast<
-    DDS::DomainParticipant_ptr>(untyped_participant);
+  DDS::DomainParticipant* participant = static_cast<
+    DDS::DomainParticipant*>(untyped_participant);
 
   register_types__@(spec.srv_name)(
     participant, request_type_name.c_str(), response_type_name.c_str());
@@ -187,7 +187,7 @@ void create_requester__@(spec.srv_name)(void * untyped_participant, const char *
         @(spec.pkg_name)::dds_::@(spec.srv_name)Response_>(
           participant, service_name, service_type_name));
 
-  DDS::DataReader_ptr typed_reader = requester->get_response_datareader();
+  DDS::DataReader* typed_reader = requester->get_response_datareader();
   *untyped_requester = requester;
   *untyped_reader = requester->get_response_datareader();
 }
@@ -200,8 +200,8 @@ void create_responder__@(spec.srv_name)(void * untyped_participant, const char *
   const std::string request_type_name("@(spec.pkg_name)::dds_::Sample@(spec.srv_name)Request_");
   const std::string response_type_name("@(spec.pkg_name)::dds_::Sample@(spec.srv_name)Response_");
 
-  DDS::DomainParticipant_ptr participant = static_cast<
-    DDS::DomainParticipant_ptr>(untyped_participant);
+  DDS::DomainParticipant* participant = static_cast<
+    DDS::DomainParticipant*>(untyped_participant);
 
   register_types__@(spec.srv_name)(
     participant, request_type_name.c_str(), response_type_name.c_str());
@@ -214,7 +214,7 @@ void create_responder__@(spec.srv_name)(void * untyped_participant, const char *
         @(spec.pkg_name)::dds_::@(spec.srv_name)Response_>(
           participant, service_name, service_type_name));
 
-  DDS::DataReader_ptr typed_reader = responder->get_request_datareader();
+  DDS::DataReader* typed_reader = responder->get_request_datareader();
   *untyped_responder = responder;
   *untyped_reader = responder->get_request_datareader();
 }


### PR DESCRIPTION
This PR replaces `_ptr` types with plain pointers.

Fixes #20 

@dirk-thomas @tfoote @wjwwood 