### PR TITLE
export type support for rmw implementation

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -31,7 +31,7 @@ configure_rmw_library(rmw_opensplice_cpp)
 
 ament_export_libraries(rmw_opensplice_cpp ${OpenSplice_LIBRARIES})
 
-register_rmw_implementation()
+register_rmw_implementation("rosidl_typesupport_opensplice_cpp")
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
This is necessary to build libraries / executable against messages / services within the same package.

Connects to ros2/rmw#11.

@esteve @tfoote @wjwwood Please review.