### PR TITLE
Fix for the idl error

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/bin/rosidl_typesupport_opensplice_cpp
+++ b/rosidl_typesupport_opensplice_cpp/bin/rosidl_typesupport_opensplice_cpp
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import sys
 
 from rosidl_parser import UnknownMessageType
 from rosidl_typesupport_opensplice_cpp import generate_dds_opensplice_cpp
 from rosidl_typesupport_opensplice_cpp import generate_typesupport_opensplice_cpp
+
+
+def is_valid_file(parser, file_name):
+    if not os.path.exists(file_name):
+        parser.error("File does not exist: '{0}'".format(file_name))
+    file_name_abs = os.path.abspath(file_name)
+    if not os.path.isfile(file_name_abs):
+        parser.error("Path exists but is not a file: '{0}'".format(file_name_abs))
+    return file_name
 
 
 def main(argv=sys.argv[1:]):
@@ -21,9 +31,10 @@ def main(argv=sys.argv[1:]):
         nargs='*',
         help='The ROS interface files')
     parser.add_argument(
-        '--dds-interface-files',
-        nargs='*',
-        help='The DDS interface files')
+        '--dds-interface-files-file',
+        required=True, metavar='FILE',
+        type=lambda x: is_valid_file(parser, x),
+        help='The file containing a list of the DDS interface files')
     parser.add_argument(
         '--dds-interface-base-path',
         required=True,
@@ -59,9 +70,12 @@ def main(argv=sys.argv[1:]):
         return 1
     if rc:
         return rc
+    dds_interface_files = []
+    with open(args.dds_interface_files_file, 'r') as f:
+        dds_interface_files = [l for l in f.read().splitlines() if l]
     return generate_dds_opensplice_cpp(
         args.pkg_name,
-        args.dds_interface_files,
+        dds_interface_files,
         args.dds_interface_base_path,
         args.deps,
         args.output_dir,

--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -119,12 +119,16 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   endforeach()
 endforeach()
 
+set(_dds_idl_files_file "${_output_path}/dds_idl_files.txt")
+string(REPLACE ";" "\n" _dds_idl_files_lines "${_dds_idl_files}")
+file(WRITE "${_dds_idl_files_file}" ${_dds_idl_files_lines})
+
 add_custom_command(
   OUTPUT ${_generated_msg_files} ${_generated_srv_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_opensplice_cpp_BIN}
   --pkg-name ${PROJECT_NAME}
   --ros-interface-files ${rosidl_generate_interfaces_IDL_FILES}
-  --dds-interface-files ${_dds_idl_files}
+  --dds-interface-files-file ${_dds_idl_files_file}
   --dds-interface-base-path ${_dds_idl_base_path}
   --deps ${_dependencies}
   --output-dir "${_output_path}"


### PR DESCRIPTION
This is a fix for the IDL error: https://github.com/ros2/rcl_interfaces/issues/2

Basically it looks like when the argument length for a custom command approaches 8192 characters long, MSBuild screws up the splicing and re-concatenating of the arguments. Resulting in a single missing character.

This pull request works around this by dumping the largest portion of the arguments into a file in the build space and then passes the path to that file to the python script which reads it and then generates a list of files from the content. Apparently this is referred to as a "response file" in Windows lingo and apparently it is done automatically for extremely long compile commands...

Connects to ros2/rcl_interfaces#2