### PR TITLE
make typesupport namespace unique for each rmw implementation

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/duration__type_support.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/duration__type_support.hpp
@@ -25,7 +25,7 @@ namespace builtin_interfaces
 {
 namespace msg
 {
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
@@ -38,7 +38,7 @@ extern void convert_dds_message_to_ros(
   const DDS::Duration_t & dds_message,
   builtin_interfaces::msg::Duration & ros_message);
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/time__type_support.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/time__type_support.hpp
@@ -25,7 +25,7 @@ namespace builtin_interfaces
 {
 namespace msg
 {
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
@@ -38,7 +38,7 @@ extern void convert_dds_message_to_ros(
   const DDS::Time_t & dds_message,
   builtin_interfaces::msg::Time & ros_message);
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces
 

--- a/rosidl_typesupport_opensplice_cpp/resource/duration__type_support.cpp
+++ b/rosidl_typesupport_opensplice_cpp/resource/duration__type_support.cpp
@@ -18,7 +18,7 @@ namespace builtin_interfaces
 {
 namespace msg
 {
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
@@ -39,6 +39,6 @@ void convert_dds_message_to_ros(
   ros_message.nanosec = dds_message.nanosec;
 }
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
@@ -43,7 +43,7 @@ namespace dds_
 {
 struct @(field.type.type)_;
 }  // namespace dds_
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 void convert_ros_message_to_dds(
   const @(field.type.pkg_name)::msg::@(field.type.type) &,
@@ -51,7 +51,7 @@ void convert_ros_message_to_dds(
 void convert_dds_message_to_ros(
   const @(field.type.pkg_name)::msg::dds_::@(field.type.type)_ &,
   @(field.type.pkg_name)::msg::@(field.type.type) &);
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace @(field.type.pkg_name)
 @[end if]@
@@ -65,7 +65,7 @@ namespace @(spec.base_type.pkg_name)
 namespace @(subfolder)
 {
 
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 @{
@@ -132,7 +132,7 @@ convert_ros_message_to_dds(const __ros_msg_type & ros_message, __dds_msg_type & 
 @[elif field.type.is_primitive_type()]@
       dds_message.@(field.name)_[i] = ros_message.@(field.name)[i];
 @[else]@
-      @(field.type.pkg_name)::msg::type_support::convert_ros_message_to_dds(
+      @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_ros_message_to_dds(
         ros_message.@(field.name)[i], dds_message.@(field.name)_[i]);
 @[end if]@
     }
@@ -142,7 +142,7 @@ convert_ros_message_to_dds(const __ros_msg_type & ros_message, __dds_msg_type & 
 @[elif field.type.is_primitive_type()]@
   dds_message.@(field.name)_ = ros_message.@(field.name);
 @[else]@
-  @(field.type.pkg_name)::msg::type_support::convert_ros_message_to_dds(
+  @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_ros_message_to_dds(
     ros_message.@(field.name), dds_message.@(field.name)_);
 @[end if]@
 
@@ -212,7 +212,7 @@ convert_dds_message_to_ros(const __dds_msg_type & dds_message, __ros_msg_type & 
 @[elif field.type.is_primitive_type()]@
       ros_message.@(field.name)[i] = dds_message.@(field.name)_[i];
 @[else]@
-      @(field.type.pkg_name)::msg::type_support::convert_dds_message_to_ros(
+      @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_dds_message_to_ros(
         dds_message.@(field.name)_[i], ros_message.@(field.name)[i]);
 @[end if]@
     }
@@ -220,7 +220,7 @@ convert_dds_message_to_ros(const __dds_msg_type & dds_message, __ros_msg_type & 
 @[elif field.type.is_primitive_type()]@
   ros_message.@(field.name) = dds_message.@(field.name)_;
 @[else]@
-  @(field.type.pkg_name)::msg::type_support::convert_dds_message_to_ros(
+  @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_dds_message_to_ros(
     dds_message.@(field.name)_, ros_message.@(field.name));
 @[end if]@
 
@@ -355,7 +355,7 @@ static rosidl_message_type_support_t handle = {
   &callbacks
 };
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 
 }  // namespace @(subfolder)
 
@@ -371,7 +371,7 @@ get_message_type_support_handle_opensplice<
   @(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)
 >()
 {
-  return &@(spec.base_type.pkg_name)::@(subfolder)::type_support::handle;
+  return &@(spec.base_type.pkg_name)::@(subfolder)::typesupport_opensplice_cpp::handle;
 }
 
 }  // namespace rosidl_typesupport_opensplice_cpp

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.hpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.hpp.template
@@ -31,7 +31,7 @@ namespace @(spec.base_type.pkg_name)
 namespace @(subfolder)
 {
 
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 void register_type__@(spec.base_type.type)(
@@ -56,7 +56,7 @@ bool take__@(spec.base_type.type)(
   void * untyped_ros_message,
   bool * taken);
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 
 }  // namespace @(subfolder)
 

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -222,7 +222,7 @@ namespace @(spec.pkg_name)
 namespace srv
 {
 
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 const char *
@@ -394,7 +394,7 @@ send_request__@(spec.srv_name)(
 
   SampleT request;
   auto ros_request = reinterpret_cast<const ROSRequestT *>(untyped_ros_request);
-  @(spec.pkg_name)::srv::type_support::convert_ros_message_to_dds(*ros_request, request.data());
+  @(spec.pkg_name)::srv::typesupport_opensplice_cpp::convert_ros_message_to_dds(*ros_request, request.data());
 
   typedef
   rosidl_typesupport_opensplice_cpp::Requester<
@@ -439,7 +439,7 @@ take_request__@(spec.srv_name)(
   }
 
   if (taken) {
-    @(spec.pkg_name)::srv::type_support::convert_dds_message_to_ros(request.data(), *ros_request);
+    @(spec.pkg_name)::srv::typesupport_opensplice_cpp::convert_dds_message_to_ros(request.data(), *ros_request);
 
     request_header->sequence_number = request.sequence_number_;
     *(reinterpret_cast<uint64_t *>(&request_header->writer_guid[0])) = request.client_guid_0_;
@@ -461,7 +461,7 @@ send_response__@(spec.srv_name)(
   typedef @(spec.pkg_name)::srv::@(spec.srv_name)_Response ROSResponseT;
   rosidl_typesupport_opensplice_cpp::Sample<@(__dds_msg_type_prefix)_Response_> response;
   auto ros_response = reinterpret_cast<const ROSResponseT *>(untyped_ros_response);
-  @(spec.pkg_name)::srv::type_support::convert_ros_message_to_dds(*ros_response, response.data());
+  @(spec.pkg_name)::srv::typesupport_opensplice_cpp::convert_ros_message_to_dds(*ros_response, response.data());
 
   auto request_header = reinterpret_cast<const rmw_request_id_t *>(untyped_ros_request_header);
 
@@ -506,7 +506,7 @@ take_response__@(spec.srv_name)(
 
     req_id->sequence_number = response.sequence_number_;
 
-    @(spec.pkg_name)::srv::type_support::convert_dds_message_to_ros(
+    @(spec.pkg_name)::srv::typesupport_opensplice_cpp::convert_dds_message_to_ros(
       response.data(), *ros_response);
     return nullptr;
   }
@@ -583,7 +583,7 @@ static rosidl_service_type_support_t handle = {
   &callbacks
 };
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 
 }  // namespace srv
 
@@ -598,7 +598,7 @@ ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
 const rosidl_service_type_support_t *
 get_service_type_support_handle_opensplice<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
-  return &@(spec.pkg_name)::srv::type_support::handle;
+  return &@(spec.pkg_name)::srv::typesupport_opensplice_cpp::handle;
 }
 
 }  // namespace rosidl_typesupport_opensplice_cpp

--- a/rosidl_typesupport_opensplice_cpp/resource/time__type_support.cpp
+++ b/rosidl_typesupport_opensplice_cpp/resource/time__type_support.cpp
@@ -18,7 +18,7 @@ namespace builtin_interfaces
 {
 namespace msg
 {
-namespace type_support
+namespace typesupport_opensplice_cpp
 {
 
 void convert_ros_message_to_dds(
@@ -37,6 +37,6 @@ void convert_dds_message_to_ros(
   ros_message.nanosec = dds_message.nanosec;
 }
 
-}  // namespace type_support
+}  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces


### PR DESCRIPTION
Otherwise message lib A from type support X might use symbols from message B from type support Y.