### PR TITLE
fix warnings

### DIFF
--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -275,7 +276,12 @@ rmw_create_publisher(
     static_cast<size_t>(datawriter_qos.history.depth) < queue_size
   )
   {
-    datawriter_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS::Long>::max)()) {
+      RMW_SET_ERROR_MSG(
+        "failed to set history depth since the requested queue size exceeds the DDS type");
+      goto fail;
+    }
+    datawriter_qos.history.depth = static_cast<DDS::Long>(queue_size);
   }
 
   topic_writer = dds_publisher->create_datawriter(
@@ -521,7 +527,12 @@ rmw_create_subscription(
     static_cast<size_t>(datareader_qos.history.depth) < queue_size
   )
   {
-    datareader_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS::Long>::max)()) {
+      RMW_SET_ERROR_MSG(
+        "failed to set history depth since the requested queue size exceeds the DDS type");
+      goto fail;
+    }
+    datareader_qos.history.depth = static_cast<DDS::Long>(queue_size);
   }
 
   topic_reader = dds_subscriber->create_datareader(
@@ -821,7 +832,7 @@ rmw_wait(
   }
 
   // add a condition for each service
-  for (unsigned long i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count; ++i) {
     OpenSpliceStaticServiceInfo * service_info =
       static_cast<OpenSpliceStaticServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -849,7 +860,7 @@ rmw_wait(
   }
 
   // add a condition for each client
-  for (unsigned long i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count; ++i) {
     OpenSpliceStaticClientInfo * client_info =
       static_cast<OpenSpliceStaticClientInfo *>(clients->clients[i]);
     if (!client_info) {
@@ -944,7 +955,7 @@ rmw_wait(
   }
 
   // set service handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count; ++i) {
     OpenSpliceStaticServiceInfo * service_info =
       static_cast<OpenSpliceStaticServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -977,7 +988,7 @@ rmw_wait(
   }
 
   // set client handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count; ++i) {
     OpenSpliceStaticClientInfo * client_info =
       static_cast<OpenSpliceStaticClientInfo *>(clients->clients[i]);
     if (!client_info) {

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
@@ -223,7 +223,8 @@ convert_dds_message_to_ros(const __dds_msg_type & dds_message, __ros_msg_type & 
 @[if field.type.type == 'bool']@
       ros_message.@(field.name)[i] = (dds_message.@(field.name)_[i] != 0);
 @[elif field.type.is_primitive_type()]@
-      ros_message.@(field.name)[i] = dds_message.@(field.name)_[i];
+      ros_message.@(field.name)[i] =
+        dds_message.@(field.name)_[i]@(' == TRUE' if field.type.type == 'bool' else '');
 @[else]@
       @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_dds_message_to_ros(
         dds_message.@(field.name)_[i], ros_message.@(field.name)[i]);
@@ -231,7 +232,8 @@ convert_dds_message_to_ros(const __dds_msg_type & dds_message, __ros_msg_type & 
     }
   }
 @[elif field.type.is_primitive_type()]@
-  ros_message.@(field.name) = dds_message.@(field.name)_;
+  ros_message.@(field.name) =
+    dds_message.@(field.name)_@(' == TRUE' if field.type.type == 'bool' else '');
 @[else]@
   @(field.type.pkg_name)::msg::typesupport_opensplice_cpp::convert_dds_message_to_ros(
     dds_message.@(field.name)_, ros_message.@(field.name));

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.template
@@ -12,7 +12,8 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#include <sstream>
+#include <limits>
+#include <stdexcept>
 
 #include <u_instanceHandle.h>
 
@@ -129,7 +130,11 @@ convert_ros_message_to_dds(const __ros_msg_type & ros_message, __dds_msg_type & 
     size_t size = @(field.type.array_size);
 @[else]@
     size_t size = ros_message.@(field.name).size();
-    dds_message.@(field.name)_.length(size);
+    if (size > (std::numeric_limits<DDS::Long>::max)()) {
+      throw std::runtime_error("array size exceeds maximum DDS sequence size");
+    }
+    DDS::Long length = static_cast<DDS::Long>(size);
+    dds_message.@(field.name)_.length(length);
 @[end if]@
     for (DDS::ULong i = 0; i < size; i++) {
 @[if field.type.type == 'string']@


### PR DESCRIPTION
* fix all warnings on OS X: http://ci.ros2.org/job/ros2_batch_ci_osx/34/
* fix 1.5k warnings on Windows: http://ci.ros2.org/job/ros2_batch_ci_windows/51/ 

The remaining Windows warnings are:
* either type conversion warnings
* or usage of deprecated functions (due to no upper limit for string processing)