### PR TITLE
link rmw_opensplice against pthread

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ ament_export_include_directories(${OpenSplice_INCLUDE_DIRS})
 
 link_directories(${OpenSplice_LIBRARY_DIRS})
 add_library(rmw_opensplice_cpp SHARED src/functions.cpp)
+target_link_libraries(rmw_opensplice_cpp pthread)
 ament_target_dependencies(rmw_opensplice_cpp
   "rmw"
   "rosidl_generator_cpp"


### PR DESCRIPTION
On Ubuntu 15.04, I found it necessary to add -lpthread . Not sure why, or where the best place is to add this link, but anyway if it goes here, the examples seem to link and run correctly.