### PR TITLE
Check error codes in attach_condition

### DIFF
--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -195,6 +195,21 @@ struct OpenSpliceStaticServiceInfo
   const service_type_support_callbacks_t * callbacks_;
 };
 
+rmw_ret_t check_attach_condition_error(DDS::ReturnCode_t retcode)
+{
+  if (retcode == DDS::RETCODE_OK) {
+    return RMW_RET_OK;
+  }
+  if (retcode == DDS::RETCODE_OUT_OF_RESOURCES) {
+    RMW_SET_ERROR_MSG("failed to attach condition to waitset: out of resources");
+  } else if (retcode == DDS::RETCODE_BAD_PARAMETER) {
+    RMW_SET_ERROR_MSG("failed to attach condition to waitset: condition pointer was invalid");
+  } else {
+    RMW_SET_ERROR_MSG("failed to attach condition to waitset");
+  }
+  return RMW_RET_ERROR;
+}
+
 const char *
 rmw_get_implementation_identifier()
 {
@@ -1112,9 +1127,10 @@ rmw_wait(
       RMW_SET_ERROR_MSG("read condition handle is null");
       return RMW_RET_ERROR;
     }
-    if (waitset.attach_condition(read_condition) != DDS::RETCODE_OK) {
-      RMW_SET_ERROR_MSG("failed to attach condition to waitset");
-      return RMW_RET_ERROR;
+    rmw_ret_t status = check_attach_condition_error(
+      waitset.attach_condition(read_condition));
+    if (status != RMW_RET_OK) {
+      return status;
     }
   }
 
@@ -1126,9 +1142,10 @@ rmw_wait(
       RMW_SET_ERROR_MSG("guard condition handle is null");
       return RMW_RET_ERROR;
     }
-    if (waitset.attach_condition(guard_condition) != DDS::RETCODE_OK) {
-      RMW_SET_ERROR_MSG("failed to attach condition to waitset");
-      return RMW_RET_ERROR;
+    rmw_ret_t status = check_attach_condition_error(
+      waitset.attach_condition(guard_condition));
+    if (status != RMW_RET_OK) {
+      return status;
     }
   }
 
@@ -1154,9 +1171,10 @@ rmw_wait(
       RMW_SET_ERROR_MSG("failed to set enabled statuses on condition");
       return RMW_RET_ERROR;
     }
-    if (waitset.attach_condition(condition) != DDS::RETCODE_OK) {
-      RMW_SET_ERROR_MSG("failed to attach condition to waitset");
-      return RMW_RET_ERROR;
+    rmw_ret_t status = check_attach_condition_error(
+      waitset.attach_condition(condition));
+    if (status != RMW_RET_OK) {
+      return status;
     }
   }
 
@@ -1182,9 +1200,10 @@ rmw_wait(
       RMW_SET_ERROR_MSG("failed to set enabled statuses on condition");
       return RMW_RET_ERROR;
     }
-    if (waitset.attach_condition(condition) != DDS::RETCODE_OK) {
-      RMW_SET_ERROR_MSG("failed to attach condition to waitset");
-      return RMW_RET_ERROR;
+    rmw_ret_t status = check_attach_condition_error(
+      waitset.attach_condition(condition));
+    if (status != RMW_RET_OK) {
+      return status;
     }
   }
 


### PR DESCRIPTION
Improve the error message for RMW_SET_ERROR_MSG based on different DDS return codes for `Waitset::attach_condition`.