### PR TITLE
set _CRT_NONSTDC_NO_DEPRECATE on Windows

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -37,7 +37,9 @@ configure_rmw_library(rmw_opensplice_cpp)
 # Additionally, on Windows, add the ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_BUILDING_DLL definition.
 if(WIN32)
   target_compile_definitions(rmw_opensplice_cpp
-      PRIVATE "ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_BUILDING_DLL")
+    PRIVATE "_CRT_NONSTDC_NO_DEPRECATE")
+  target_compile_definitions(rmw_opensplice_cpp
+    PRIVATE "ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_BUILDING_DLL")
 endif()
 
 ament_export_libraries(rmw_opensplice_cpp ${OpenSplice_LIBRARIES})


### PR DESCRIPTION
Fixes 2 warnings: http://ci.ros2.org/job/ros2_batch_ci_windows/203/warnings34Result/fixed/

Connects to ros2/ros2#53