### PR TITLE
do not override OSPL config in environment if it's already setup.

### DIFF
--- a/opensplice_cmake_module/env_hook/opensplice.sh.in
+++ b/opensplice_cmake_module/env_hook/opensplice.sh.in
@@ -1,10 +1,16 @@
 export OSPL_HOME=@OpenSplice_HOME@
+
 if [ -f "$OSPL_HOME/release.com" ]; then
   . "$OSPL_HOME/release.com" > /dev/null
 else
   export OSPL_TMPL_PATH=$OSPL_HOME/etc/opensplice/idlpp
-  export OSPL_URI=file://$OSPL_HOME/etc/opensplice/config/ospl.xml
-
+  _DEFAULT_OSPL_URI=file://$OSPL_HOME/etc/opensplice/config/ospl.xml
+  if [ -z "$OSPL_URI" ]; then
+    export OSPL_URI=$_DEFAULT_OSPL_URI
+  elif [ "$OSPL_URI" != "$_DEFAULT_OSPL_URI" ]; then
+    echo "Warning: OSPL_URI was already set to [[$OSPL_URI]]. This will not override it to the default [[$_DEFAULT_OSPL_URI]]. Please make sure this is the config that you want." 1>&2
+  fi
+  unset _DEFAULT_OSPL_URI
   # detect if running on Darwin platform
   _UNAME=`uname -s`
   _IS_DARWIN=0


### PR DESCRIPTION
This allows the user to set OSPL_HOME OSPL_URI in their environment to override things like the ROS_DOMAIN_ID

Otherwise they have to reset those variables after entering a workspace. needed [here](https://github.com/ros2/examples/wiki)

http://ci.ros2.org/job/ros2_batch_ci_linux/268/
http://ci.ros2.org/job/ros2_batch_ci_osx/188/