### PR TITLE
declare unwanted but implicit dependency

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 find_package(ament_cmake_python REQUIRED)
 
+ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)

--- a/rosidl_typesupport_opensplice_cpp/package.xml
+++ b/rosidl_typesupport_opensplice_cpp/package.xml
@@ -21,6 +21,8 @@
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>
 
+  <build_export_depend>rmw</build_export_depend>
+
   <exec_depend>rosidl_parser</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Until this implicitly dependency is removed (ros2/rmw_opensplice#39) it must be declared correctly declared in order to not break isolated builds.