### PR TITLE
Support changing the ROS_DOMAIN_ID in OpenSplice without changing the config file

### DIFF
--- a/opensplice_cmake_module/CMakeLists.txt
+++ b/opensplice_cmake_module/CMakeLists.txt
@@ -30,3 +30,6 @@ ament_package(
 
 install(DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME})

--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -1,0 +1,55 @@
+<OpenSplice>
+   <Domain>
+      <Name>ospl_sp_ddsi</Name>
+      <Id>${ROS_DOMAIN_ID}</Id>
+      <SingleProcess>true</SingleProcess>
+      <Service name="ddsi2">
+         <Command>ddsi2</Command>
+      </Service>
+      <Service name="durability">
+         <Command>durability</Command>
+      </Service>
+      <Service enabled="false" name="cmsoap">
+         <Command>cmsoap</Command>
+      </Service>
+   </Domain>
+   <DDSI2Service name="ddsi2">
+      <General>
+         <NetworkInterfaceAddress>AUTO</NetworkInterfaceAddress>
+         <AllowMulticast>true</AllowMulticast>
+         <EnableMulticastLoopback>true</EnableMulticastLoopback>
+         <CoexistWithNativeNetworking>false</CoexistWithNativeNetworking>
+      </General>
+      <Compatibility>
+<!-- see the release notes and/or the OpenSplice configurator on DDSI interoperability -->
+         <StandardsConformance>lax</StandardsConformance>
+<!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
+<!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
+      </Compatibility>
+   </DDSI2Service>
+   <DurabilityService name="durability">
+      <Network>
+         <Alignment>
+            <TimeAlignment>false</TimeAlignment>
+            <RequestCombinePeriod>
+               <Initial>2.5</Initial>
+               <Operational>0.1</Operational>
+            </RequestCombinePeriod>
+         </Alignment>
+         <WaitForAttachment maxWaitCount="10">
+            <ServiceName>ddsi2</ServiceName>
+         </WaitForAttachment>
+      </Network>
+      <NameSpaces>
+         <NameSpace name="defaultNamespace">
+            <Partition>*</Partition>
+         </NameSpace>
+         <Policy alignee="Initial" aligner="true" durability="Durable" nameSpace="defaultNamespace"/>
+      </NameSpaces>
+   </DurabilityService>
+   <TunerService name="cmsoap">
+      <Server>
+         <PortNr>Auto</PortNr>
+      </Server>
+   </TunerService>
+</OpenSplice>

--- a/opensplice_cmake_module/env_hook/opensplice.bat.in
+++ b/opensplice_cmake_module/env_hook/opensplice.bat.in
@@ -2,6 +2,11 @@ set "OSPL_HOME=@OpenSplice_HOME@"
 
 call "%OSPL_HOME%\release.bat" 1> nul
 
+set "OSPL_URI=file://%AMENT_CURRENT_PREFIX%/share/opensplice_cmake_module/config/ros_ospl.xml"
 set "OSPL_INFOFILE=<stdout>"
 set "OSPL_ERRORFILE=<stderr>"
 set OSPL_VERBOSITY=2
+
+:: If ROS_DOMAIN_ID is not set, set it to the default of 0.
+:: This is required because rmw_opensplice_cpp cannot work unless it is set.
+if "%ROS_DOMAIN_ID%"=="" set ROS_DOMAIN_ID=0

--- a/opensplice_cmake_module/env_hook/opensplice.sh.in
+++ b/opensplice_cmake_module/env_hook/opensplice.sh.in
@@ -1,16 +1,20 @@
 export OSPL_HOME=@OpenSplice_HOME@
 
+_DEFAULT_OSPL_URI="file://$AMENT_CURRENT_PREFIX/share/opensplice_cmake_module/config/ros_ospl.xml"
+
 if [ -f "$OSPL_HOME/release.com" ]; then
+  _ORIGINAL_OSPL_URI="$OSPL_URI"
   . "$OSPL_HOME/release.com" > /dev/null
+  if [ -n "$_ORIGINAL_OSPL_URI" ]; then
+    # If the OSPL_URI was set before sourcing the release.com script, restore it.
+    export OSPL_URI="$_ORIGINAL_OSPL_URI"
+  else
+    # Otherwise override the OSPL_URI from the release.com with the ros default config.
+    export OSPL_URI="$_DEFAULT_OSPL_URI"
+  fi
+  unset _ORIGINAL_OSPL_URI
 else
   export OSPL_TMPL_PATH=$OSPL_HOME/etc/opensplice/idlpp
-  _DEFAULT_OSPL_URI=file://$OSPL_HOME/etc/opensplice/config/ospl.xml
-  if [ -z "$OSPL_URI" ]; then
-    export OSPL_URI=$_DEFAULT_OSPL_URI
-  elif [ "$OSPL_URI" != "$_DEFAULT_OSPL_URI" ]; then
-    echo "Warning: OSPL_URI was already set to [[$OSPL_URI]]. This will not override it to the default [[$_DEFAULT_OSPL_URI]]. Please make sure this is the config that you want." 1>&2
-  fi
-  unset _DEFAULT_OSPL_URI
   # detect if running on Darwin platform
   _UNAME=`uname -s`
   _IS_DARWIN=0
@@ -26,6 +30,14 @@ else
   fi
   unset _IS_DARWIN
 fi
+
+if [ -z "$OSPL_URI" ]; then
+  export OSPL_URI="$_DEFAULT_OSPL_URI"
+elif [ "$OSPL_URI" != "$_DEFAULT_OSPL_URI" ]; then
+  echo "Warning: OSPL_URI was already set to [[$OSPL_URI]]. This will not override it to the default [[$_DEFAULT_OSPL_URI]]. Please make sure this is the config that you want." 1>&2
+fi
+
+unset _DEFAULT_OSPL_URI
 
 export OSPL_INFOFILE="<stdout>"
 export OSPL_ERRORFILE="<stderr>"


### PR DESCRIPTION
Currently you have to update the system installed OpenSplice config file, or override it using `OSPL_URI` in order to use a different `ROS_DOMAIN_ID`. This is out of sync with the other implementations and inconvenient.

So this pull request works around this issue by copying the default configuration for OpenSplice into the `opensplice_cmake_module` package, replacing the default domain id (`0`) with `${ROS_DOMAIN_ID}`, installing it to the workspace, and changing the environment hooks to default to referencing this file rather than the built-in one. This means that when this config file is evaluated by OpenSplice it will substitute the `${ROS_DOMAIN_ID}` in the config file with what ever is in the environment. This strategy is based on the feedback I got on their forum:

http://forums.opensplice.org/index.php?/topic/2591-programmatically-choosing-the-domain-id/#entry4471

The other thing we have to do is to ensure that the `ROS_DOMAIN_ID` is set before trying to use OpenSplice, and therefore forcing the configuration file to be evaluated. See https://github.com/ros2/rclcpp/pull/102

Still testing, not quite ready for review.