### PR TITLE
Fix default QoS settings for services

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
@@ -40,7 +40,8 @@ public:
     service_type_name_(service_type_name), sequence_number_(0)
   {}
 
-  const char * init() noexcept
+  const char * init(const DDS::DataReaderQos * datareader_qos,
+    const DDS::DataWriterQos * datawriter_qos) noexcept
   {
     std::random_device rd;
     std::default_random_engine e1(rd());
@@ -61,9 +62,7 @@ public:
     DDS::ReturnCode_t status;
     DDS::TopicQos default_topic_qos;
     DDS::PublisherQos publisher_qos;
-    DDS::DataWriterQos default_datawriter_qos;
     DDS::SubscriberQos subscriber_qos;
-    DDS::DataReaderQos default_datareader_qos;
     std::string request_type_name = service_type_name_ + "_Request_";
     std::string request_topic_name = service_name_ + "_Request";
     std::string response_type_name = service_type_name_ + "_Response_";
@@ -103,13 +102,8 @@ public:
       goto fail;
     }
 
-    status = request_publisher_->get_default_datawriter_qos(default_datawriter_qos);
-    if (nullptr != (estr = impl::check_get_default_datawriter_qos(status))) {
-      goto fail;
-    }
-
     request_datawriter_ = request_publisher_->create_datawriter(
-      request_topic_, default_datawriter_qos, NULL, DDS::STATUS_MASK_NONE);
+      request_topic_, *datawriter_qos, NULL, DDS::STATUS_MASK_NONE);
     if (!request_datawriter_) {
       estr = "Publisher::create_datawriter: failed for request";
       goto fail;
@@ -146,14 +140,9 @@ public:
       goto fail;
     }
 
-    status = response_subscriber_->get_default_datareader_qos(default_datareader_qos);
-    if (nullptr != (estr = impl::check_get_default_datareader_qos(status))) {
-      goto fail;
-    }
-
     response_datareader_ = response_subscriber_->create_datareader(
       content_filtered_response_topic_,
-      default_datareader_qos, NULL, DDS::STATUS_MASK_NONE);
+      *datareader_qos, NULL, DDS::STATUS_MASK_NONE);
     if (!response_datareader_) {
       estr = "Subscriber::create_datawriter: failed for response";
       goto fail;

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -38,14 +38,14 @@ public:
     service_name_(service_name), service_type_name_(service_type_name)
   {}
 
-  const char * init()
+  const char * init(const DDS::DataReaderQos * datareader_qos,
+    const DDS::DataWriterQos * datawriter_qos)
   {
+
     DDS::ReturnCode_t status;
     DDS::TopicQos default_topic_qos;
     DDS::SubscriberQos subscriber_qos;
-    DDS::DataReaderQos default_datareader_qos;
     DDS::PublisherQos publisher_qos;
-    DDS::DataWriterQos default_datawriter_qos;
     std::string request_type_name = service_type_name_ + "_Request_";
     std::string request_topic_name = service_name_ + "_Request";
     std::string response_type_name = service_type_name_ + "_Response_";
@@ -85,14 +85,9 @@ public:
       goto fail;
     }
 
-    status = request_subscriber_->get_default_datareader_qos(default_datareader_qos);
-    if (nullptr != (estr = impl::check_get_default_datareader_qos(status))) {
-      goto fail;
-    }
-
     request_datareader_ = request_subscriber_->create_datareader(
       request_topic_,
-      default_datareader_qos, NULL, DDS::STATUS_MASK_NONE);
+      *datareader_qos, NULL, DDS::STATUS_MASK_NONE);
     if (!request_datareader_) {
       estr = "Subscriber::create_datareader: failed";
       goto fail;
@@ -119,13 +114,8 @@ public:
       goto fail;
     }
 
-    status = response_publisher_->get_default_datawriter_qos(default_datawriter_qos);
-    if (nullptr != (estr = impl::check_get_default_datawriter_qos(status))) {
-      goto fail;
-    }
-
     response_datawriter_ = response_publisher_->create_datawriter(
-      response_topic_, default_datawriter_qos, NULL, DDS::STATUS_MASK_NONE);
+      response_topic_, *datawriter_qos, NULL, DDS::STATUS_MASK_NONE);
     if (!response_datawriter_) {
       estr = "Publisher::create_datawriter: failed";
       goto fail;

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
@@ -29,7 +29,7 @@ typedef struct service_type_support_callbacks_t
   // Passing NULL to the allocator will result in malloc being used.
   const char * (*create_requester)(
     void * participant, const char * service_name, void ** requester, void ** reader,
-    void * (*allocator)(size_t));
+    const void * datareader_qos, const void * datawriter_qos, void * (*allocator)(size_t));
   // De-allocatea a requester
   // The deallocator should match the allocator passed to create_requester.
   // Returns NULL if the requester was successfully destroyed, otherwise an error string.
@@ -40,7 +40,7 @@ typedef struct service_type_support_callbacks_t
   // Passing NULL to the allocator will result in malloc being used.
   const char * (*create_responder)(
     void * participant, const char * service_name, void ** responder, void ** reader,
-    void * (*allocator)(size_t));
+    const void * datareader_qos, const void * datawriter_qos, void * (*allocator)(size_t));
   // De-allocatea a responder
   // The deallocator should match the allocator passed to create_respnder.
   // Returns NULL if the responder was successfully destroyed, otherwise an error string.

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -279,6 +279,8 @@ const char *
 create_requester__@(spec.srv_name)(
   void * untyped_participant, const char * service_name,
   void **untyped_requester, void ** untyped_reader,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
   void * (* allocator)(size_t))
 {
   auto _allocator = allocator ? allocator : &malloc;
@@ -288,6 +290,9 @@ create_requester__@(spec.srv_name)(
 
   DDS::DomainParticipant * participant =
     static_cast<DDS::DomainParticipant *>(untyped_participant);
+
+  const DDS::DataReaderQos * datareader_qos = static_cast<const DDS::DataReaderQos *>(untyped_datareader_qos);
+  const DDS::DataWriterQos * datawriter_qos = static_cast<const DDS::DataWriterQos *>(untyped_datawriter_qos);
 
   const char * error_string = register_types__@(spec.srv_name)(
     participant, request_type_name.c_str(), response_type_name.c_str());
@@ -316,7 +321,7 @@ create_requester__@(spec.srv_name)(
     // throw exceptions below.
     return "C++ exception caught during construction of RequesterT";
   }
-  error_string = requester->init();
+  error_string = requester->init(datareader_qos, datawriter_qos);
   if (error_string) {
     return error_string;
   }
@@ -331,6 +336,8 @@ const char *
 create_responder__@(spec.srv_name)(
   void * untyped_participant, const char * service_name,
   void **untyped_responder, void **untyped_reader,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
   void * (* allocator)(size_t))
 {
   auto _allocator = allocator ? allocator : &malloc;
@@ -341,7 +348,10 @@ create_responder__@(spec.srv_name)(
   DDS::DomainParticipant * participant =
     static_cast<DDS::DomainParticipant *>(untyped_participant);
 
-  const char * error_string = register_types__@(spec.srv_name)(
+  const DDS::DataReaderQos * datareader_qos = static_cast<const DDS::DataReaderQos *>(untyped_datareader_qos);
+  const DDS::DataWriterQos * datawriter_qos = static_cast<const DDS::DataWriterQos *>(untyped_datawriter_qos);
+
+   const char * error_string = register_types__@(spec.srv_name)(
     participant, request_type_name.c_str(), response_type_name.c_str());
   if (error_string) {
     return error_string;
@@ -368,7 +378,7 @@ create_responder__@(spec.srv_name)(
     // throw exceptions below.
     return "C++ exception caught during construction of ResponderT";
   }
-  error_string = responder->init();
+  error_string = responder->init(datareader_qos, datawriter_qos);
   if (error_string) {
     return error_string;
   }


### PR DESCRIPTION
Connects to ros2/rmw_connext#96

This fixes the issue @esteve and @dirk-thomas have observed where the `add_two_ints` client does not receive the response from the server unless it was started after the server was initialized. You may still see a few seconds between when the server is initialized and when the client receives the message, but the client should receive the response eventually.

I'm willing to wait on the service tests to be stable before others review. Otherwise you can use the `add_two_ints` example to test it.

Eventually we should consider if we want to expose QoS options for services, but I think this is better default behavior for now.

Connext PR: ros2/rmw_connext/pull/100