### PR TITLE
Added logic to set durability QoS settings

### DIFF
--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -89,6 +89,9 @@ bool set_entity_qos_from_profile(const rmw_qos_profile_t & qos_profile,
     case RMW_QOS_POLICY_TRANSIENT_LOCAL_DURABILITY:
       entity_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
       break;
+    case RMW_QOS_POLICY_VOLATILE_DURABILITY:
+      entity_qos.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
+      break;
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       break;
     default:

--- a/rmw_opensplice_cpp/src/functions.cpp
+++ b/rmw_opensplice_cpp/src/functions.cpp
@@ -85,6 +85,17 @@ bool set_entity_qos_from_profile(const rmw_qos_profile_t & qos_profile,
       return false;
   }
 
+  switch (qos_profile.durability) {
+    case RMW_QOS_POLICY_TRANSIENT_LOCAL_DURABILITY:
+      entity_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+      break;
+    case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
+      break;
+    default:
+      RMW_SET_ERROR_MSG("Unknown QoS durability policy");
+      return false;
+  }
+
   if (qos_profile.depth != RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT) {
     entity_qos.history.depth =
       static_cast<DDS::Long>(qos_profile.depth);


### PR DESCRIPTION
This PR adds the logic needed to apply the durability policy to data readers and writers.

Connects to ros2/rmw#41