### PR TITLE
increase fragment size

### DIFF
--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -26,6 +26,9 @@
             <!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
             <!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
         </Compatibility>
+        <Internal>
+            <FragmentSize>64000B</FragmentSize>
+        </Internal>
     </DDSI2Service>
     <DurabilityService name="durability">
         <Network>


### PR DESCRIPTION
Prevent fragmentation as much as possible to work with FastRTPS in more cases for now.

Makes the last interop test pass: http://ci.ros2.org/job/ros2_batch_ci_linux/395/

Connect to ros2/ros2#124