### PR TITLE
Teardown functions

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -164,6 +164,77 @@ fail:
     return estr;
   }
 
+  const char * teardown() noexcept
+  {
+    const char * estr = nullptr;
+    DDS::ReturnCode_t status;
+    if (response_datawriter_) {
+      status = response_publisher_->delete_datawriter(response_datawriter_);
+      if (nullptr != impl::check_delete_datawriter(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_datawriter(status));
+        estr = "Error from Publisher::delete_datawriter in responder teardown";
+      }
+    }
+    if (response_topic_) {
+      status = participant_->delete_topic(response_topic_);
+      if (nullptr != impl::check_delete_topic(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_topic(status));
+        if (estr) {
+          // print the old error string if it needs to be overwritten
+          fprintf(stderr, "%s\n", estr);
+        }
+        estr = "Error from Participant::delete_topic in responder teardown";
+      }
+    }
+    if (response_publisher_) {
+      status = participant_->delete_publisher(response_publisher_);
+      if (nullptr != impl::check_delete_publisher(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_publisher(status));
+        if (estr) {
+          // print the old error string if it needs to be overwritten
+          fprintf(stderr, "%s\n", estr);
+        }
+        estr = "Error from Participant::delete_publisher in responder teardown";
+      }
+    }
+    if (request_datareader_) {
+      // Assumption: subscriber is not null at this point.
+      status = request_subscriber_->delete_datareader(request_datareader_);
+      if (nullptr != impl::check_delete_datareader(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_datareader(status));
+        if (estr) {
+          // print the old error string if it needs to be overwritten
+          fprintf(stderr, "%s\n", estr);
+        }
+        estr = "Error from Subscriber::delete_datareader in responder teardown";
+      }
+    }
+    if (request_subscriber_) {
+      status = participant_->delete_subscriber(request_subscriber_);
+      if (nullptr != impl::check_delete_subscriber(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_subscriber(status));
+        if (estr) {
+          // print the old error string if it needs to be overwritten
+          fprintf(stderr, "%s\n", estr);
+        }
+        estr = "Error from Participant::delete_subscriber in responder teardown";
+      }
+    }
+    if (request_topic_) {
+      status = participant_->delete_topic(request_topic_);
+      if (nullptr != impl::check_delete_topic(status)) {
+        fprintf(stderr, "%s\n", impl::check_delete_topic(status));
+        if (estr) {
+          // print the old error string if it needs to be overwritten
+          fprintf(stderr, "%s\n", estr);
+        }
+        estr = "Error from Participant::delete_topic in responder teardown";
+      }
+    }
+    return estr;
+  }
+
+
   DDS::DataReader * get_request_datareader()
   {
     return request_datareader_;

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -519,6 +519,7 @@ destroy_requester__@(spec.srv_name)(void * untyped_requester, void (* deallocato
   >;
 
   auto requester = static_cast<RequesterT *>(untyped_requester);
+  const char * teardown_status = requester->teardown();
   try {
     requester->~RequesterT();
   } catch(...) {
@@ -528,7 +529,9 @@ destroy_requester__@(spec.srv_name)(void * untyped_requester, void (* deallocato
     // throw exceptions below.
     return "C++ exception caught during destruction of RequesterT";
   }
-  // TODO(wjwwood): we need a "deinit" function on the class to undo anything done in the init().
+  if (teardown_status != nullptr) {
+    return teardown_status;
+  }
   auto _deallocator = deallocator ? deallocator : &free;
   _deallocator(requester);
   return nullptr;
@@ -542,6 +545,7 @@ destroy_responder__@(spec.srv_name)(void * untyped_responder, void (* deallocato
     @(__dds_msg_type_prefix)_Response_
   >;
   auto responder = static_cast<ResponderT *>(untyped_responder);
+  const char * teardown_status = responder->teardown();
   try {
     responder->~ResponderT();
   } catch(...) {
@@ -551,7 +555,9 @@ destroy_responder__@(spec.srv_name)(void * untyped_responder, void (* deallocato
     // throw exceptions below.
     return "C++ exception caught during destruction of ResponderT";
   }
-  // TODO(wjwwood): we need a "deinit" function on the class to undo anything done in the init().
+  if (teardown_status != nullptr) {
+    return teardown_status;
+  }
   auto _deallocator = deallocator ? deallocator : &free;
   _deallocator(responder);
   return nullptr;


### PR DESCRIPTION
Fixes ros2/rmw_opensplice#47

This also fixes a bug with our implementation of Opensplice requesters that I discovered while using multiple clients on the same topic by giving the ContentFilteredTopic a unique name based on the writer GUID of the requester.