### PR TITLE
Use global WaitSet to be reused in rmw_wait

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(rmw_opensplice_cpp SHARED
   src/rmw_trigger_guard_condition.cpp
   src/rmw_wait.cpp
   src/types.cpp
+  src/waitset.cpp
 )
 ament_target_dependencies(rmw_opensplice_cpp
   "rmw"

--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -21,6 +21,8 @@
 
 #include "types.hpp"
 
+#include "waitset.hpp"
+
 // The extern "C" here enforces that overloading is not used.
 extern "C"
 {
@@ -47,7 +49,7 @@ rmw_wait(
   rmw_clients_t * clients,
   rmw_time_t * wait_timeout)
 {
-  DDS::WaitSet waitset;
+  //DDS::WaitSet waitset;
 
   // add a condition for each subscriber
   for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
@@ -63,7 +65,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
     rmw_ret_t status = check_attach_condition_error(
-      waitset.attach_condition(read_condition));
+      opensplice_cpp_waitset.attach_condition(read_condition));
     if (status != RMW_RET_OK) {
       return status;
     }
@@ -78,7 +80,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
     rmw_ret_t status = check_attach_condition_error(
-      waitset.attach_condition(guard_condition));
+      opensplice_cpp_waitset.attach_condition(guard_condition));
     if (status != RMW_RET_OK) {
       return status;
     }
@@ -98,7 +100,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
     rmw_ret_t status = check_attach_condition_error(
-      waitset.attach_condition(read_condition));
+      opensplice_cpp_waitset.attach_condition(read_condition));
     if (status != RMW_RET_OK) {
       return status;
     }
@@ -118,7 +120,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
     rmw_ret_t status = check_attach_condition_error(
-      waitset.attach_condition(read_condition));
+      opensplice_cpp_waitset.attach_condition(read_condition));
     if (status != RMW_RET_OK) {
       return status;
     }
@@ -133,7 +135,7 @@ rmw_wait(
     timeout.sec = static_cast<DDS::Long>(wait_timeout->sec);
     timeout.nanosec = static_cast<DDS::Long>(wait_timeout->nsec);
   }
-  DDS::ReturnCode_t status = waitset.wait(active_conditions, timeout);
+  DDS::ReturnCode_t status = opensplice_cpp_waitset.wait(active_conditions, timeout);
 
   if (status == DDS::RETCODE_TIMEOUT) {
     return RMW_RET_TIMEOUT;
@@ -153,6 +155,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
     DDS::ReadCondition * read_condition = subscriber_info->read_condition;
+    opensplice_cpp_waitset.detach_condition(read_condition);
     if (!read_condition) {
       RMW_SET_ERROR_MSG("read condition handle is null");
       return RMW_RET_ERROR;
@@ -173,6 +176,7 @@ rmw_wait(
       return RMW_RET_ERROR;
     }
 
+    opensplice_cpp_waitset.detach_condition(guard_condition);
     if (!guard_condition->get_trigger_value()) {
       // if the guard condition was not triggered
       // reset the guard condition handle
@@ -199,6 +203,7 @@ rmw_wait(
       RMW_SET_ERROR_MSG("read condition handle is null");
       return RMW_RET_ERROR;
     }
+    opensplice_cpp_waitset.detach_condition(read_condition);
 
     // search for service condition in active set
     uint32_t j = 0;
@@ -227,6 +232,7 @@ rmw_wait(
       RMW_SET_ERROR_MSG("read condition handle is null");
       return RMW_RET_ERROR;
     }
+    opensplice_cpp_waitset.detach_condition(read_condition);
 
     // search for service condition in active set
     uint32_t j = 0;

--- a/rmw_opensplice_cpp/src/waitset.cpp
+++ b/rmw_opensplice_cpp/src/waitset.cpp
@@ -1,0 +1,21 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//#ifndef WAITSET_HPP_
+//#define WAITSET_HPP_
+#include "waitset.hpp"
+
+DDS::WaitSet opensplice_cpp_waitset;
+
+//#endif  // WAITSET_HPP_

--- a/rmw_opensplice_cpp/src/waitset.hpp
+++ b/rmw_opensplice_cpp/src/waitset.hpp
@@ -1,0 +1,24 @@
+
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WAITSET_HPP_
+#define WAITSET_HPP_
+
+#include <ccpp_dds_dcps.h>
+#include <dds_dcps.h>
+
+extern DDS::WaitSet opensplice_cpp_waitset;
+
+#endif  // WAITSET_HPP_


### PR DESCRIPTION
In progress. I'd appreciate some preliminary feedback on this approach.

TODO:

Global ConditionSeq to be used rmw_wait (with option to pre-allocate)
Matching updates to Connext
Should the global shared variables be initialized/de-initialized in rmw_init/rmw_shutdown?