### PR TITLE
Use memcpy to avoid breaking strict-aliasing rules

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -18,6 +18,7 @@
 #include <ccpp_dds_dcps.h>
 #include <u_entity.h>
 
+#include <cstring>
 #include <string>
 
 #include "rosidl_typesupport_opensplice_cpp/impl/error_checking.hpp"
@@ -250,9 +251,11 @@ fail:
   noexcept
   {
     response.sequence_number_ = request_header.sequence_number;
-    response.client_guid_0_ = *(reinterpret_cast<const uint64_t *>(&request_header.writer_guid[0]));
-    response.client_guid_1_ = *(reinterpret_cast<const uint64_t *>(
-        &request_header.writer_guid[0] + sizeof(response.client_guid_0_)));
+    std::memcpy(
+      &response.client_guid_0_, &request_header.writer_guid[0], sizeof(response.client_guid_0_));
+    std::memcpy(
+      &response.client_guid_1_, &request_header.writer_guid[0] + sizeof(response.client_guid_0_),
+      sizeof(response.client_guid_1_));
 
     return TemplateDataWriter<Sample<ResponseT>>::write_sample(response_datawriter_, response);
   }

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -9,6 +9,7 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
+#include <cstring>
 #include <iostream>
 #include <sstream>
 
@@ -442,9 +443,11 @@ take_request__@(spec.srv_name)(
     @(spec.pkg_name)::srv::typesupport_opensplice_cpp::convert_dds_message_to_ros(request.data(), *ros_request);
 
     request_header->sequence_number = request.sequence_number_;
-    *(reinterpret_cast<uint64_t *>(&request_header->writer_guid[0])) = request.client_guid_0_;
-    *(reinterpret_cast<uint64_t *>(
-      &request_header->writer_guid[0] + sizeof(request.client_guid_0_))) = request.client_guid_1_;
+    std::memcpy(
+      &request_header->writer_guid[0], &request.client_guid_0_, sizeof(request.client_guid_0_));
+    std::memcpy(
+      &request_header->writer_guid[0] + sizeof(request.client_guid_0_),
+      &request.client_guid_1_, sizeof(request.client_guid_1_));
 
     *taken = true;
     return nullptr;


### PR DESCRIPTION
This fixes a compiler warning.