### PR TITLE
Use a set to avoid multiple forward declarations for the same type

### DIFF
--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
@@ -69,10 +69,17 @@ ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(pkg), @(subfolder), @(msg))();
 have_not_included_primitive_arrays = True
 have_not_included_string = True
 }@
-@{
-field_types = set([field.type for field in spec.fields])
+{
+from collections import OrderedDict
+field_types = {}
+for field in spec.fields:
+    if not field.type.is_primitive_type():
+        full_field = field.type.pkg_name + '__msg__' + field.type.type
+        if full_field not in field_types:
+            field_types[full_field] = field.type
+field_types = OrderedDict(sorted(field_types.items()))
 }@
-@[for field_type in field_types]@
+@[for full_field, field_type in field_types.items()]@
 @[if field_type.is_primitive_type()]@
 @[if field_type.is_array and have_not_included_primitive_arrays]@
 @{have_not_included_primitive_arrays = False}@

--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
@@ -69,30 +69,33 @@ ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(pkg), @(subfolder), @(msg))();
 have_not_included_primitive_arrays = True
 have_not_included_string = True
 }@
-@[for field in spec.fields]@
-@[if field.type.is_primitive_type()]@
-@[if field.type.is_array and have_not_included_primitive_arrays]@
+@{
+field_types = set([field.type for field in spec.fields])
+}@
+@[for field_type in field_types]@
+@[if field_type.is_primitive_type()]@
+@[if field_type.is_array and have_not_included_primitive_arrays]@
 @{have_not_included_primitive_arrays = False}@
 #include <rosidl_generator_c/primitives_array.h>
 #include <rosidl_generator_c/primitives_array_functions.h>
 
 @[end if]@
-@[if field.type.type == 'string' and have_not_included_string]@
+@[if field_type.type == 'string' and have_not_included_string]@
 @{have_not_included_string = False}@
 #include <rosidl_generator_c/string.h>
 #include <rosidl_generator_c/string_functions.h>
 
 @[end if]@
 @[else]@
-// Include helper functions for type @(field.type.type)
-@{header_file_name = get_header_filename_from_msg_name(field.type.type)}@
-#include <@(field.type.pkg_name)/msg/@(header_file_name)__functions.h>
-// Forward declare the get type support function for @(field.type.type)
-@[if field.type.pkg_name != pkg]@
+// Include helper functions for type @(field_type.type)
+@{header_file_name = get_header_filename_from_msg_name(field_type.type)}@
+#include <@(field_type.pkg_name)/msg/@(header_file_name)__functions.h>
+// Forward declare the get type support function for @(field_type.type)
+@[if field_type.pkg_name != pkg]@
 ROSIDL_GENERATOR_C_IMPORT_@(spec.base_type.pkg_name)
 @[end if]@
 const rosidl_message_type_support_t *
-ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(field.type.pkg_name), msg, @(field.type.type))();
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(field_type.pkg_name), msg, @(field_type.type))();
 
 @[end if]@
 @[end for]@

--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.template
@@ -70,16 +70,10 @@ have_not_included_primitive_arrays = True
 have_not_included_string = True
 }@
 {
-from collections import OrderedDict
-field_types = {}
-for field in spec.fields:
-    if not field.type.is_primitive_type():
-        full_field = field.type.pkg_name + '__msg__' + field.type.type
-        if full_field not in field_types:
-            field_types[full_field] = field.type
-field_types = OrderedDict(sorted(field_types.items()))
+from collections import OrderedSet
+field_types = OrderedSet(sorted([field.type for field in spec.fields]))
 }@
-@[for full_field, field_type in field_types.items()]@
+@[for field_type in field_types]@
 @[if field_type.is_primitive_type()]@
 @[if field_type.is_array and have_not_included_primitive_arrays]@
 @{have_not_included_primitive_arrays = False}@


### PR DESCRIPTION
This prevents repeating a forward declarations when a message contains multiple fields with the same type, e.g. https://github.com/ros2/rosidl/blob/master/rosidl_generator_py/msg/Nested.msg#L3