### PR TITLE
null not triggered conditions on timeout

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -240,11 +240,7 @@ rmw_wait(
   }
   DDS::ReturnCode_t status = dds_waitset->wait(*active_conditions, timeout);
 
-  if (status == DDS::RETCODE_TIMEOUT) {
-    return RMW_RET_TIMEOUT;
-  }
-
-  if (status != DDS::RETCODE_OK) {
+  if (status != DDS::RETCODE_OK && status != DDS::RETCODE_TIMEOUT) {
     RMW_SET_ERROR_MSG("failed to wait on waitset");
     return RMW_RET_ERROR;
   }
@@ -347,6 +343,10 @@ rmw_wait(
     if (!(j < active_conditions->length())) {
       clients->clients[i] = 0;
     }
+  }
+
+  if (status == DDS::RETCODE_TIMEOUT) {
+    return RMW_RET_TIMEOUT;
   }
   return RMW_RET_OK;
 }


### PR DESCRIPTION
Otherwise `rclcpp` considers all conditions "active".

Based on what @gerkey discovered while looking into ros2/rclcpp#192.

http://ci.ros2.org/job/ci_linux/961/
http://ci.ros2.org/job/ci_osx/801/
Waiting for http://ci.ros2.org/job/ci_windows/1052/