### PR TITLE
fix inconsistent instance state flags which results in a busy loop

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -88,6 +88,8 @@ public:
       1,
       DDS::ANY_SAMPLE_STATE,
       DDS::ANY_VIEW_STATE,
+      // See ros2/rclcpp#192 for a justification of this option:
+      // https://github.com/ros2/rclcpp/issues/192#issuecomment-183491185
       DDS::ANY_INSTANCE_STATE);
 
     switch (status) {

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.template
@@ -88,7 +88,7 @@ public:
       1,
       DDS::ANY_SAMPLE_STATE,
       DDS::ANY_VIEW_STATE,
-      DDS::ALIVE_INSTANCE_STATE);
+      DDS::ANY_INSTANCE_STATE);
 
     switch (status) {
       case DDS::RETCODE_ERROR:


### PR DESCRIPTION
Based on the investigations here: https://github.com/ros2/rclcpp/issues/192#issuecomment-183491185

It makes the test from the `issue_192` branch work for me locally.

* http://ci.ros2.org/job/ci_linux/975/
* http://ci.ros2.org/job/ci_osx/810/
* http://ci.ros2.org/job/ci_windows/1063/