### PR TITLE
Register language of typesupport packages

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -79,8 +79,8 @@ endif()
 ament_export_libraries(rmw_opensplice_cpp)
 
 register_rmw_implementation(
-  c "rosidl_typesupport_opensplice_c"
-  cpp "rosidl_typesupport_opensplice_cpp")
+  "c:rosidl_typesupport_opensplice_c"
+  "cpp:rosidl_typesupport_opensplice_cpp")
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -79,8 +79,8 @@ endif()
 ament_export_libraries(rmw_opensplice_cpp)
 
 register_rmw_implementation(
-  C "rosidl_typesupport_opensplice_c"
-  CPP "rosidl_typesupport_opensplice_cpp")
+  c "rosidl_typesupport_opensplice_c"
+  cpp "rosidl_typesupport_opensplice_cpp")
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -78,8 +78,9 @@ endif()
 
 ament_export_libraries(rmw_opensplice_cpp)
 
-# register_rmw_implementation("rosidl_typesupport_opensplice_c;rosidl_typesupport_opensplice_cpp")
-register_rmw_implementation("rosidl_typesupport_opensplice_cpp")
+register_rmw_implementation(
+  C "rosidl_typesupport_opensplice_c"
+  CPP "rosidl_typesupport_opensplice_cpp")
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
Connects to ros2/rmw#63

New usage of `register_typesupport_implementation` is needed.