### PR TITLE
also search for opensplice in ament prefix path

### DIFF
--- a/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
+++ b/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
@@ -90,7 +90,8 @@ if(NOT "${_ospl_home} " STREQUAL " ")
   set(OpenSplice_FOUND TRUE)
 else()
   # try to find_package() it
-  find_package(opensplice NO_MODULE COMPONENTS CXX PATHS /usr /usr/local)
+  find_package(opensplice NO_MODULE COMPONENTS CXX
+    PATHS $ENV{AMENT_PREFIX_PATH} /usr /usr/local)
   if(OPENSPLICE_FOUND)
     message(STATUS "Found PrismTech OpenSplice: ${opensplice_DIR}")
     set(OpenSplice_HOME "${OPENSPLICE_PREFIX}")

--- a/opensplice_cmake_module/package.xml
+++ b/opensplice_cmake_module/package.xml
@@ -8,7 +8,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>libopensplice64</build_depend>
+  <build_depend>opensplice</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Allows to build opensplice within an ament workspace (currently necessary on platforms we don't have Debian packages for, e.g. Xenial).

Depends on ament/ament_tools#93.