### PR TITLE
Fix warnings on Windows

### DIFF
--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -220,7 +220,7 @@ if(WIN32)
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PRIVATE "ROSIDL_TYPESUPPORT_OPENSPLICE_C_BUILDING_DLL")
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    PRIVATE "ROSIDL_GENERATOR_C_${PROJECT_NAME}_BUILDING_DLL")
+    PRIVATE "ROSIDL_GENERATOR_C_BUILDING_DLL_${PROJECT_NAME}")
 endif()
 # The following still uses CPP because the OpenSplice code which uses it was generated for CPP.
 target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -219,6 +219,8 @@ if(WIN32)
     PRIVATE "ROSIDL_BUILDING_DLL")
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PRIVATE "ROSIDL_TYPESUPPORT_OPENSPLICE_C_BUILDING_DLL")
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_GENERATOR_C_${PROJECT_NAME}_BUILDING_DLL")
 endif()
 # The following still uses CPP because the OpenSplice code which uses it was generated for CPP.
 target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -61,11 +61,6 @@ extern "C"
 {
 #endif
 
-// Forward declare the get type support function for this type.
-ROSIDL_GENERATOR_C_EXPORT_@(spec.base_type.pkg_name)
-const rosidl_message_type_support_t *
-  ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(pkg), @(subfolder), @(msg))();
-
 // include message dependencies
 @{
 includes = {}

--- a/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
@@ -17,7 +17,6 @@
 // This is defined in the rosidl_typesupport_opensplice_c package and
 // is in the include/rosidl_typesupport_opensplice_c/impl folder.
 #include "rosidl_generator_c/message_type_support.h"
-#include "rosidl_typesupport_opensplice_c/visibility_control.h"
 #include "rmw/rmw.h"
 
 @{header_file_name = get_header_filename_from_msg_name(spec.srv_name)}@


### PR DESCRIPTION
This should fix the warnings on Windows for generated Opensplice C messages.