### PR TITLE
changes to support wait for service (round 2)

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_count.cpp
+++ b/rmw_opensplice_cpp/src/rmw_count.cpp
@@ -55,13 +55,7 @@ rmw_count_publishers(
     return RMW_RET_ERROR;
   }
 
-  const auto & topic_names_and_types = node_info->publisher_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
-  if (it == topic_names_and_types.end()) {
-    *count = 0;
-  } else {
-    *count = it->second.size();
-  }
+  *count = node_info->publisher_listener->count_topic(topic_name);
   return RMW_RET_OK;
 }
 
@@ -98,13 +92,7 @@ rmw_count_subscribers(
     return RMW_RET_ERROR;
   }
 
-  const auto & topic_names_and_types = node_info->subscriber_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
-  if (it == topic_names_and_types.end()) {
-    *count = 0;
-  } else {
-    *count = it->second.size();
-  }
+  *count = node_info->subscriber_listener->count_topic(topic_name);
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_opensplice_cpp/src/rmw_topic_names_and_types.cpp
+++ b/rmw_opensplice_cpp/src/rmw_topic_names_and_types.cpp
@@ -97,16 +97,8 @@ rmw_get_topic_names_and_types(
 
   // combine publisher and subscriber information
   std::map<std::string, std::set<std::string>> topics_with_multiple_types;
-  for (auto it : node_info->publisher_listener->topic_names_and_types) {
-    for (auto & jt : it.second) {
-      topics_with_multiple_types[it.first].insert(jt);
-    }
-  }
-  for (auto it : node_info->subscriber_listener->topic_names_and_types) {
-    for (auto & jt : it.second) {
-      topics_with_multiple_types[it.first].insert(jt);
-    }
-  }
+  node_info->publisher_listener->fill_topic_names_and_types(topics_with_multiple_types);
+  node_info->subscriber_listener->fill_topic_names_and_types(topics_with_multiple_types);
 
   // ignore inconsistent types
   std::map<std::string, std::string> topics;

--- a/rmw_opensplice_cpp/src/types.cpp
+++ b/rmw_opensplice_cpp/src/types.cpp
@@ -27,6 +27,30 @@ create_type_name(
          "::" + sep + "::dds_::" + callbacks->message_name + "_";
 }
 
+size_t
+CustomDataReaderListener::count_topic(const char * topic_name)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = topic_names_and_types_.find(topic_name);
+  if (it == topic_names_and_types_.end()) {
+    return 0;
+  } else {
+    return it->second.size();
+  }
+}
+
+void
+CustomDataReaderListener::fill_topic_names_and_types(
+  std::map<std::string, std::set<std::string>> & tnat)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto it : topic_names_and_types_) {
+    for (auto & jt : it.second) {
+      tnat[it.first].insert(jt);
+    }
+  }
+}
+
 void
 CustomDataReaderListener::add_information(
   const DDS::SampleInfo & sample_info,
@@ -34,29 +58,29 @@ CustomDataReaderListener::add_information(
   const std::string & type_name)
 {
   // store topic name and type name
-  auto & topic_types = topic_names_and_types[topic_name];
+  auto & topic_types = topic_names_and_types_[topic_name];
   topic_types.insert(type_name);
   // store mapping to instance handle
   TopicDescriptor topic_descriptor;
   topic_descriptor.instance_handle = sample_info.instance_handle;
   topic_descriptor.name = topic_name;
   topic_descriptor.type = type_name;
-  topic_descriptors.push_back(topic_descriptor);
+  topic_descriptors_.push_back(topic_descriptor);
 }
 
 void
 CustomDataReaderListener::remove_information(const DDS::SampleInfo & sample_info)
 {
   // find entry by instance handle
-  for (auto it = topic_descriptors.begin(); it != topic_descriptors.end(); ++it) {
+  for (auto it = topic_descriptors_.begin(); it != topic_descriptors_.end(); ++it) {
     if (it->instance_handle == sample_info.instance_handle) {
       // remove entries
-      auto & topic_types = topic_names_and_types[it->name];
+      auto & topic_types = topic_names_and_types_[it->name];
       topic_types.erase(topic_types.find(it->type));
       if (topic_types.empty()) {
-        topic_names_and_types.erase(it->name);
+        topic_names_and_types_.erase(it->name);
       }
-      topic_descriptors.erase(it);
+      topic_descriptors_.erase(it);
       break;
     }
   }
@@ -70,6 +94,7 @@ CustomPublisherListener::CustomPublisherListener(rmw_guard_condition_t * graph_g
 void
 CustomPublisherListener::on_data_available(DDS::DataReader * reader)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   DDS::PublicationBuiltinTopicDataDataReader * builtin_reader =
     DDS::PublicationBuiltinTopicDataDataReader::_narrow(reader);
 
@@ -117,6 +142,7 @@ CustomSubscriberListener::CustomSubscriberListener(rmw_guard_condition_t * graph
 void
 CustomSubscriberListener::on_data_available(DDS::DataReader * reader)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   DDS::SubscriptionBuiltinTopicDataDataReader * builtin_reader =
     DDS::SubscriptionBuiltinTopicDataDataReader::_narrow(reader);
 

--- a/rmw_opensplice_cpp/src/types.cpp
+++ b/rmw_opensplice_cpp/src/types.cpp
@@ -56,7 +56,7 @@ CustomDataReaderListener::CustomDataReaderListener()
       print_discovery_logging_ = true;
     }
 #ifdef _WIN32
-    free(ospl_uri);
+    free(discovery_logging_value);
 #endif
   }
 }

--- a/rmw_opensplice_cpp/src/types.cpp
+++ b/rmw_opensplice_cpp/src/types.cpp
@@ -68,9 +68,8 @@ CustomDataReaderListener::count_topic(const char * topic_name)
   auto it = topic_names_and_types_.find(topic_name);
   if (it == topic_names_and_types_.end()) {
     return 0;
-  } else {
-    return it->second.size();
   }
+  return it->second.size();
 }
 
 void

--- a/rmw_opensplice_cpp/src/types.cpp
+++ b/rmw_opensplice_cpp/src/types.cpp
@@ -15,6 +15,7 @@
 #include "types.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <map>
 #include <set>
 #include <string>
@@ -48,7 +49,9 @@ CustomDataReaderListener::CustomDataReaderListener()
   if (discovery_logging_value) {
     std::string str(discovery_logging_value, discovery_logging_size);
     std::string str_lower(str);
-    std::transform(str_lower.begin(), str_lower.end(), str_lower.begin(), std::tolower);
+    std::transform(str_lower.begin(), str_lower.end(), str_lower.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
     if (str != "0" && str_lower != "false" && str_lower != "off") {
       print_discovery_logging_ = true;
     }

--- a/rmw_opensplice_cpp/src/types.hpp
+++ b/rmw_opensplice_cpp/src/types.hpp
@@ -20,6 +20,7 @@
 
 #include <list>
 #include <map>
+#include <mutex>
 #include <set>
 #include <string>
 
@@ -62,7 +63,9 @@ public:
   void on_sample_lost(
     DDS::DataReader_ptr, const DDS::SampleLostStatus &)
   {}
-  std::map<std::string, std::multiset<std::string>> topic_names_and_types;
+
+  void fill_topic_names_and_types(std::map<std::string, std::set<std::string>> & tnat);
+  size_t count_topic(const char * topic_name);
 
 protected:
   virtual void add_information(
@@ -71,6 +74,8 @@ protected:
     const std::string & type_name);
   virtual void remove_information(const DDS::SampleInfo & sample_info);
 
+  std::mutex mutex_;
+
 private:
   struct TopicDescriptor
   {
@@ -78,7 +83,8 @@ private:
     std::string name;
     std::string type;
   };
-  std::list<TopicDescriptor> topic_descriptors;
+  std::map<std::string, std::multiset<std::string>> topic_names_and_types_;
+  std::list<TopicDescriptor> topic_descriptors_;
 };
 
 class CustomPublisherListener

--- a/rmw_opensplice_cpp/src/types.hpp
+++ b/rmw_opensplice_cpp/src/types.hpp
@@ -42,6 +42,8 @@ class CustomDataReaderListener
   : public DDS::DataReaderListener
 {
 public:
+  CustomDataReaderListener();
+
   void on_requested_deadline_missed(
     DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus &)
   {}
@@ -67,12 +69,21 @@ public:
   void fill_topic_names_and_types(std::map<std::string, std::set<std::string>> & tnat);
   size_t count_topic(const char * topic_name);
 
+  enum EndPointType
+  {
+    PublisherEP,
+    SubscriberEP,
+  };
+
 protected:
   virtual void add_information(
     const DDS::SampleInfo & sample_info,
     const std::string & topic_name,
-    const std::string & type_name);
-  virtual void remove_information(const DDS::SampleInfo & sample_info);
+    const std::string & type_name,
+    EndPointType end_point_type);
+  virtual void remove_information(
+    const DDS::SampleInfo & sample_info,
+    EndPointType end_point_type);
 
   std::mutex mutex_;
 
@@ -85,6 +96,7 @@ private:
   };
   std::map<std::string, std::multiset<std::string>> topic_names_and_types_;
   std::list<TopicDescriptor> topic_descriptors_;
+  bool print_discovery_logging_;
 };
 
 class CustomPublisherListener

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -376,7 +376,7 @@ finally:
              "the data_values and info_seq were not obtained from this "
              "@(__dds_msg_type_prefix)DataReader";
     case DDS::RETCODE_OK:
-      return nullptr;
+      break;
     default:
       return "@(__dds_msg_type_prefix)DataReader.return_loan failed with "
              "unknown return code";

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
@@ -122,11 +122,9 @@ public:
                "unknown return code";
     }
 
-    if (sample_infos.length() > 0 && sample_infos[0].valid_data) {
+    *taken = (sample_infos.length() > 0 && sample_infos[0].valid_data);
+    if (*taken) {
       sample = reinterpret_cast<Sample<@(__dds_msg_type_prefix)@(suffix)_> &>(dds_messages[0]);
-      *taken = true;
-    } else {
-      *taken = false;
     }
     status = typed_datareader->return_loan(dds_messages, sample_infos);
     switch (status) {

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
@@ -124,6 +124,9 @@ public:
 
     if (sample_infos.length() > 0 && sample_infos[0].valid_data) {
       sample = reinterpret_cast<Sample<@(__dds_msg_type_prefix)@(suffix)_> &>(dds_messages[0]);
+      *taken = true;
+    } else {
+      *taken = false;
     }
     status = typed_datareader->return_loan(dds_messages, sample_infos);
     switch (status) {
@@ -146,14 +149,12 @@ public:
                "the data_values and info_seq were not obtained from this "
                "@(__dds_sample_type_prefix)@(suffix)_DataReader";
       case DDS::RETCODE_OK:
-        *taken = true;
-        return nullptr;
+        break;
       default:
         return "@(__dds_sample_type_prefix)@(suffix)_DataReader.return_loan failed with "
                "unknown return code";
     }
 
-    *taken = false;
     return nullptr;
   }
 };


### PR DESCRIPTION
The important change in this pr is that it adds mutex locking around access to the data structures where we store discovery information. For our OpenSplice implementation, the thread in which the data is added/removed is always different then thread that is asking for the information through `rmw_count_{publishers, subscribers}` and `rmw_get_topic_names_and_types`.

The other change was to introduce some extra console logging of discovery activity with the `RMW_PRINT_DISCOVERY_LOGGING` env variable.

Connects to ros2/ros2#215