### PR TITLE
add builtin subscriber teardown to opensplice

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -278,12 +278,12 @@ rmw_destroy_node(rmw_node_t * node)
   }
 
   auto result = RMW_RET_OK;
-  
+
   // Explicitly delete the builtin_subscriber, which is
   // apparently required because we accessed it in rmw_create_node().
   DDS::Subscriber * builtin_subscriber = participant->get_builtin_subscriber();
   if (builtin_subscriber) {
-    if (participant->delete_subscriber(builtin_subscriber)!= DDS::RETCODE_OK) {
+    if (participant->delete_subscriber(builtin_subscriber) != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("builtin subscriber handle failed to delete");
       result = RMW_RET_ERROR;
     }

--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -296,7 +296,6 @@ rmw_destroy_node(rmw_node_t * node)
     result = RMW_RET_ERROR;
   }
 
-
   if (dp_factory->delete_participant(participant) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to delete participant");
     result = RMW_RET_ERROR;

--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -285,6 +285,15 @@ rmw_destroy_node(rmw_node_t * node)
     result = RMW_RET_ERROR;
   }
 
+  // The builtin subscriber is not cleaned up by the above.
+  DDS::Subscriber * builtin_subscriber = participant->get_builtin_subscriber();
+  if (builtin_subscriber) {
+    if (participant->delete_subscriber(builtin_subscriber)!= DDS::RETCODE_OK) {
+      RMW_SET_ERROR_MSG("builtin subscriber handle failed to delete");
+      result = RMW_RET_ERROR;
+    }
+  }
+
   if (dp_factory->delete_participant(participant) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to delete participant");
     result = RMW_RET_ERROR;


### PR DESCRIPTION
This is the fix for the invalid teardowns discovered in #99 

The `delete_contained_entities` explicitly only cleans up the user created entities and does not delete the  builtin datatypes. 

Running the repeated tests before would produce thousands of threads, and every run would get slower due to left over participants etc. With this change it cleans up all the participants and their threads. 

**CI**
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1424)](http://ci.ros2.org/job/ci_linux/1424/)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1107)](http://ci.ros2.org/job/ci_osx/1107/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1438)](http://ci.ros2.org/job/ci_windows/1438/)