### PR TITLE
Add warning for empty OSPL_HOME variable

### DIFF
--- a/opensplice_cmake_module/env_hook/opensplice.bat.in
+++ b/opensplice_cmake_module/env_hook/opensplice.bat.in
@@ -1,4 +1,7 @@
-set "OSPL_HOME=@OpenSplice_HOME@"
+if "%OSPL_HOME%" == "" (
+  set "OSPL_HOME=@OpenSplice_HOME@"	
+  echo OSPL_HOME variable not set. Assuming %OSPL_HOME%
+)
 
 call "%OSPL_HOME%\release.bat" 1> nul
 


### PR DESCRIPTION
warn the user before setting default location for opensplice
