### PR TITLE
match API change in rmw

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -181,7 +181,7 @@ fail:
 }
 
 rmw_ret_t
-rmw_destroy_client(rmw_client_t * client)
+rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
   if (!client) {
     RMW_SET_ERROR_MSG("client handle is null");

--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -183,6 +183,7 @@ fail:
 rmw_ret_t
 rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
+  (void)node;
   if (!client) {
     RMW_SET_ERROR_MSG("client handle is null");
     return RMW_RET_ERROR;

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -171,7 +171,7 @@ fail:
 }
 
 rmw_ret_t
-rmw_destroy_service(rmw_service_t * service)
+rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
   if (!service) {
     RMW_SET_ERROR_MSG("service handle is null");

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -173,6 +173,7 @@ fail:
 rmw_ret_t
 rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
+  (void)node;
   if (!service) {
     RMW_SET_ERROR_MSG("service handle is null");
     return RMW_RET_ERROR;


### PR DESCRIPTION
follow-up of https://github.com/ros2/rmw/commit/baf307f343a36b6636894cfcd1175d54ed7a8798
This will throw an unused warning rather than an error next time we build rmw_opensplice_cpp
