### PR TITLE
expose template declaration publically and unify naming

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -55,7 +55,7 @@ rmw_create_client(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     type support,
     type_support->typesupport_identifier,
-    rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+    rosidl_typesupport_opensplice_cpp::typesupport_identifier,
     return nullptr)
 
   if (!qos_profile) {

--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -61,7 +61,7 @@ rmw_create_publisher(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     type support,
     type_support->typesupport_identifier,
-    rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+    rosidl_typesupport_opensplice_cpp::typesupport_identifier,
     return nullptr)
 
   if (!qos_profile) {

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -54,7 +54,7 @@ rmw_create_service(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     type support,
     type_support->typesupport_identifier,
-    rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+    rosidl_typesupport_opensplice_cpp::typesupport_identifier,
     return nullptr)
 
   if (!qos_profile) {

--- a/rmw_opensplice_cpp/src/rmw_subscription.cpp
+++ b/rmw_opensplice_cpp/src/rmw_subscription.cpp
@@ -62,7 +62,7 @@ rmw_create_subscription(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     type support,
     type_support->typesupport_identifier,
-    rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+    rosidl_typesupport_opensplice_cpp::typesupport_identifier,
     return nullptr)
 
   if (!qos_profile) {

--- a/rosidl_typesupport_opensplice_c/src/identifier.cpp
+++ b/rosidl_typesupport_opensplice_c/src/identifier.cpp
@@ -24,7 +24,7 @@ extern "C"
 ROSIDL_TYPESUPPORT_OPENSPLICE_C_EXPORT
 const char *
   rosidl_typesupport_opensplice_c__identifier =
-  rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier;
+  rosidl_typesupport_opensplice_cpp::typesupport_identifier;
 
 #if defined(__cplusplus)
 }

--- a/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
@@ -41,6 +41,8 @@ target_include_directories(${PROJECT_NAME}
 )
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_typesupport_cpp")
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/identifier.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/identifier.hpp
@@ -21,7 +21,7 @@ namespace rosidl_typesupport_opensplice_cpp
 {
 
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_IMPORT
-extern const char * typesupport_opensplice_identifier;
+extern const char * typesupport_identifier;
 
 }  // namespace rosidl_typesupport_opensplice_cpp
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
@@ -23,18 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_message_type_support_handle.
 #include <rosidl_generator_cpp/message_type_support_decl.hpp>
+// Provides the declaration of the function template
+#include "rosidl_typesupport_opensplice_cpp/message_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
-#include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
-
-namespace rosidl_typesupport_opensplice_cpp
-{
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
-const rosidl_message_type_support_t * get_message_type_support_handle_opensplice();
-
-}  // namespace rosidl_typesupport_opensplice_cpp
+#include "rosidl_typesupport_opensplice_cpp/visibility_control.h"
 
 namespace rosidl_generator_cpp
 {
@@ -49,7 +41,7 @@ const rosidl_message_type_support_t * get_message_type_support_handle()
   // message library. This is intentional to allow the linker to pick the
   // correct implementation specific message library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_opensplice_cpp::get_message_type_support_handle_opensplice<T>();
+  return ::rosidl_typesupport_opensplice_cpp::get_message_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
@@ -23,8 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_service_type_support_handle.
 #include <rosidl_generator_cpp/service_type_support_decl.hpp>
+// Provides the declaration of the function template
+#include "rosidl_typesupport_opensplice_cpp/service_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
-#include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
+#include "rosidl_typesupport_opensplice_cpp/visibility_control.h"
 
 namespace rosidl_typesupport_opensplice_cpp
 {
@@ -37,11 +39,6 @@ class TemplateDataReader;
 
 template<typename T>
 class TemplateDataWriter;
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
-const rosidl_service_type_support_t * get_service_type_support_handle_opensplice();
 
 }  // namespace rosidl_typesupport_opensplice_cpp
 
@@ -58,7 +55,7 @@ const rosidl_service_type_support_t * get_service_type_support_handle()
   // service library. This is intentional to allow the linker to pick the
   // correct implementation specific service library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_opensplice_cpp::get_service_type_support_handle_opensplice<T>();
+  return rosidl_typesupport_opensplice_cpp::get_service_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support_decl.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support_decl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2014-2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_message_type_support_t struct.
+#include <rosidl_generator_c/message_type_support_struct.h>
+// Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
 #include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
 
 namespace rosidl_typesupport_opensplice_cpp
 {
 
-ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
-const char * typesupport_identifier = "opensplice_static";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
+const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_typesupport_opensplice_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support_decl.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support_decl.hpp
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_service_type_support_t struct.
+#include <rosidl_generator_c/service_type_support.h>
+// Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
 #include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
 
 namespace rosidl_typesupport_opensplice_cpp
 {
 
-ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
-const char * typesupport_identifier = "opensplice_static";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
+const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_typesupport_opensplice_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_opensplice_cpp/resource/duration__type_support.cpp
+++ b/rosidl_typesupport_opensplice_cpp/resource/duration__type_support.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rosidl_generator_cpp/message_type_support.hpp"
+
 #include "rosidl_typesupport_opensplice_cpp/duration__type_support.hpp"
 
 namespace builtin_interfaces
@@ -42,3 +44,16 @@ void convert_dds_message_to_ros(
 }  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces
+
+namespace rosidl_typesupport_opensplice_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
+const rosidl_message_type_support_t *
+get_message_type_support_handle<builtin_interfaces::msg::Duration>()
+{
+  return 0;
+}
+
+}  // namespace rosidl_typesupport_opensplice_cpp

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -396,7 +396,7 @@ static message_type_support_callbacks_t callbacks = {
 };
 
 static rosidl_message_type_support_t handle = {
-  rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+  rosidl_typesupport_opensplice_cpp::typesupport_identifier,
   &callbacks
 };
 
@@ -412,7 +412,7 @@ namespace rosidl_typesupport_opensplice_cpp
 template<>
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
 const rosidl_message_type_support_t *
-get_message_type_support_handle_opensplice<
+get_message_type_support_handle<
   @(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)
 >()
 {

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
@@ -586,7 +586,7 @@ static service_type_support_callbacks_t callbacks = {
 };
 
 static rosidl_service_type_support_t handle = {
-  rosidl_typesupport_opensplice_cpp::typesupport_opensplice_identifier,
+  rosidl_typesupport_opensplice_cpp::typesupport_identifier,
   &callbacks
 };
 
@@ -603,7 +603,7 @@ namespace rosidl_typesupport_opensplice_cpp
 template<>
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
 const rosidl_service_type_support_t *
-get_service_type_support_handle_opensplice<@(spec.pkg_name)::srv::@(spec.srv_name)>()
+get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
   return &@(spec.pkg_name)::srv::typesupport_opensplice_cpp::handle;
 }

--- a/rosidl_typesupport_opensplice_cpp/resource/time__type_support.cpp
+++ b/rosidl_typesupport_opensplice_cpp/resource/time__type_support.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rosidl_generator_cpp/message_type_support.hpp"
+
 #include "rosidl_typesupport_opensplice_cpp/time__type_support.hpp"
 
 namespace builtin_interfaces
@@ -40,3 +42,16 @@ void convert_dds_message_to_ros(
 }  // namespace typesupport_opensplice_cpp
 }  // namespace msg
 }  // namespace builtin_interfaces
+
+namespace rosidl_typesupport_opensplice_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT
+const rosidl_message_type_support_t *
+get_message_type_support_handle<builtin_interfaces::msg::Time>()
+{
+  return 0;
+}
+
+}  // namespace rosidl_typesupport_opensplice_cpp


### PR DESCRIPTION
This will unify the symbols across the type support packages so that they only differ in the namespace.

Connect to ros2/rosidl_typesupport#1.