### PR TITLE
Fix to use c_utilities package

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -24,14 +24,14 @@ if(NOT rosidl_typesupport_opensplice_cpp_FOUND OR NOT rosidl_typesupport_openspl
   return()
 endif()
 
-find_package(rmw REQUIRED)
 find_package(c_utilities REQUIRED)
+find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
 ament_export_dependencies(
-  rmw
   c_utilities
+  rmw
   rosidl_generator_c
   rosidl_generator_cpp
   rosidl_typesupport_opensplice_c
@@ -66,8 +66,8 @@ add_library(rmw_opensplice_cpp SHARED
   src/types.cpp
 )
 ament_target_dependencies(rmw_opensplice_cpp
-  "rmw"
   "c_utilities"
+  "rmw"
   "rosidl_generator_c"
   "rosidl_generator_cpp"
   "rosidl_typesupport_opensplice_c"

--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -25,11 +25,13 @@ if(NOT rosidl_typesupport_opensplice_cpp_FOUND OR NOT rosidl_typesupport_openspl
 endif()
 
 find_package(rmw REQUIRED)
+find_package(c_utilities REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
 ament_export_dependencies(
   rmw
+  c_utilities
   rosidl_generator_c
   rosidl_generator_cpp
   rosidl_typesupport_opensplice_c
@@ -65,6 +67,7 @@ add_library(rmw_opensplice_cpp SHARED
 )
 ament_target_dependencies(rmw_opensplice_cpp
   "rmw"
+  "c_utilities"
   "rosidl_generator_c"
   "rosidl_generator_cpp"
   "rosidl_typesupport_opensplice_c"

--- a/rmw_opensplice_cpp/package.xml
+++ b/rmw_opensplice_cpp/package.xml
@@ -15,9 +15,9 @@
   <buildtool_export_depend>opensplice_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
+  <build_depend>c_utilities</build_depend>
   <build_depend>libopensplice64</build_depend>
   <build_depend>rmw</build_depend>
-  <build_depend>c_utilities</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_opensplice_c</build_depend>

--- a/rmw_opensplice_cpp/package.xml
+++ b/rmw_opensplice_cpp/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>libopensplice64</build_depend>
   <build_depend>rmw</build_depend>
+  <build_depend>c_utilities</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_opensplice_c</build_depend>

--- a/rmw_opensplice_cpp/src/rmw_node_names.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node_names.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "c_utilities/types.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
-#include "c_utilities/types.h"
 
 // TODO(karsten1987): Implement based on
 // https://github.com/PrismTech/opensplice/blob/master/docs/pdf/OpenSplice_refman_CPP.pdf

--- a/rmw_opensplice_cpp/src/rmw_node_names.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node_names.cpp
@@ -32,11 +32,4 @@ rmw_get_node_names(
   return RMW_RET_ERROR;
 }
 
-rmw_ret_t
-rmw_destroy_node_names(
-  utilities_string_array_t * /* node_names */)
-{
-  RMW_SET_ERROR_MSG("destroy_node_names is not supported for Opensplice");
-  return RMW_RET_ERROR;
-}
 }  // extern "C"

--- a/rmw_opensplice_cpp/src/rmw_node_names.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node_names.cpp
@@ -15,6 +15,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
+#include "c_utilities/types.h"
 
 // TODO(karsten1987): Implement based on
 // https://github.com/PrismTech/opensplice/blob/master/docs/pdf/OpenSplice_refman_CPP.pdf
@@ -25,7 +26,7 @@ extern "C"
 rmw_ret_t
 rmw_get_node_names(
   const rmw_node_t * /* node */,
-  rmw_string_array_t * /* node_names */)
+  utilities_string_array_t * /* node_names */)
 {
   RMW_SET_ERROR_MSG("get_node_names is not supported for Opensplice");
   return RMW_RET_ERROR;
@@ -33,7 +34,7 @@ rmw_get_node_names(
 
 rmw_ret_t
 rmw_destroy_node_names(
-  rmw_string_array_t * /* node_names */)
+  utilities_string_array_t * /* node_names */)
 {
   RMW_SET_ERROR_MSG("destroy_node_names is not supported for Opensplice");
   return RMW_RET_ERROR;


### PR DESCRIPTION
Fail when build on Debian.

```
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp:28:3: error: ‘rmw_string_array_t’ has not been declared
   rmw_string_array_t * /* node_names */)
   ^~~~~~~~~~~~~~~~~~
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp: In function ‘rmw_ret_t rmw_get_node_names(const rmw_node_t*, int*)’:
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp:26:1: error: conflicting declaration of C function ‘rmw_ret_t rmw_get_node_names(const rmw_node_t*, int*)’
 rmw_get_node_names(
 ^~~~~~~~~~~~~~~~~~
In file included from .../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp:16:0:
.../ros2_alfred/install_isolated/rmw/include/rmw/rmw.h:339:1: note: previous declaration ‘rmw_ret_t rmw_get_node_names(const rmw_node_t*, utilities_string_array_t*)’
 rmw_get_node_names(
 ^~~~~~~~~~~~~~~~~~
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp: At global scope:
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp:36:3: error: ‘rmw_string_array_t’ was not declared in this scope
   rmw_string_array_t * /* node_names */)
   ^~~~~~~~~~~~~~~~~~
.../src/ros2/rmw_opensplice/rmw_opensplice_cpp/src/rmw_node_names.cpp:36:40: error: expected primary-expression before ‘)’ token
   rmw_string_array_t * /* node_names */)
```

Not sure of solution but all work fine. (copy from [rmw_fastrtps#112](https://github.com/ros2/rmw_fastrtps/pull/102) )