### PR TITLE
fix cpplint failures

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -206,7 +206,8 @@ rmw_create_node(const char * name, const char * namespace_, size_t domain_id)
   }
   memcpy(const_cast<char *>(node->name), name, strlen(name) + 1);
 
-  node->namespace_ = reinterpret_cast<const char *>(rmw_allocate(sizeof(char) * strlen(namespace_) + 1));
+  node->namespace_ = reinterpret_cast<const char *>(
+    rmw_allocate(sizeof(char) * strlen(namespace_) + 1));
   if (!node->namespace_) {
     RMW_SET_ERROR_MSG("failed to allocate memory for node namespace");
     goto fail;

--- a/rmw_opensplice_cpp/src/rmw_node_names.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node_names.cpp
@@ -31,5 +31,4 @@ rmw_get_node_names(
   RMW_SET_ERROR_MSG("get_node_names is not supported for Opensplice");
   return RMW_RET_ERROR;
 }
-
 }  // extern "C"


### PR DESCRIPTION
this fixes the style test failures introduced in https://github.com/ros2/rmw_opensplice/pull/164 and https://github.com/ros2/rmw_opensplice/pull/162