### PR TITLE
update to use OpenSplice 6.7

### DIFF
--- a/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
+++ b/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
@@ -44,7 +44,10 @@
 set(OpenSplice_FOUND FALSE)
 
 # check if provided OSPL_HOME is from an "official" binary package
-file(TO_CMAKE_PATH "$ENV{OSPL_HOME}" _ospl_home)
+set(_ospl_home "")
+if(DEFINED ENV{OSPL_HOME})
+  file(TO_CMAKE_PATH "$ENV{OSPL_HOME}" _ospl_home)
+endif()
 if(WIN32)
   set(_ospl_release_file release.bat)
 else()

--- a/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
+++ b/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
@@ -76,7 +76,6 @@ if(NOT _ospl_home STREQUAL "")
     "ddsserialization"
     "ddsuser"
     "ddsutil"
-    "durability"
     "spliced"
     # we can't link against both sacpp and isocpp at the same time
     #"dcpsisocpp"

--- a/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
+++ b/opensplice_cmake_module/cmake/Modules/FindOpenSplice.cmake
@@ -106,6 +106,28 @@ else()
     set(OpenSplice_FOUND TRUE)
   endif()
 endif()
+
+# convert libraries into absolute paths
+set(_libs ${OpenSplice_LIBRARIES})
+set(OpenSplice_LIBRARIES)
+foreach(_library ${_libs})
+  if(NOT IS_ABSOLUTE "${_library}")
+    set(_lib "NOTFOUND")
+    find_library(
+      _lib "${_library}"
+      HINTS ${OpenSplice_LIBRARY_DIRS})
+    if(NOT _lib)
+      message(FATAL_ERROR "OpenSplice exports the library '${_library}' which couldn't be found")
+    elseif(NOT IS_ABSOLUTE "${_lib}")
+      message(FATAL_ERROR "The OpenSplice library '${_library}' was found at '${_lib}' which is not an absolute path")
+    elseif(NOT EXISTS "${_lib}")
+      message(FATAL_ERROR "The OpenSplice library '${_library}' was found at '${_lib}' which doesn't exist")
+    endif()
+    set(_library "${_lib}")
+  endif()
+  list(APPEND OpenSplice_LIBRARIES "${_library}")
+endforeach()
+
 if(NOT WIN32)
   list(APPEND OpenSplice_LIBRARIES "pthread" "dl")
 endif()

--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -6,9 +6,9 @@
         <Service name="ddsi2">
             <Command>ddsi2</Command>
         </Service>
-        <Service name="durability">
-            <Command>durability</Command>
-        </Service>
+        <DurablePolicies>
+            <Policy obtain="*.*"/>
+        </DurablePolicies>
         <Service enabled="false" name="cmsoap">
             <Command>cmsoap</Command>
         </Service>
@@ -19,6 +19,7 @@
             <AllowMulticast>true</AllowMulticast>
             <EnableMulticastLoopback>true</EnableMulticastLoopback>
             <CoexistWithNativeNetworking>false</CoexistWithNativeNetworking>
+            <FragmentSize>64000B</FragmentSize>
         </General>
         <Compatibility>
             <!-- see the release notes and/or the OpenSplice configurator on DDSI interoperability -->
@@ -26,30 +27,7 @@
             <!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
             <!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
         </Compatibility>
-        <Internal>
-            <FragmentSize>64000B</FragmentSize>
-        </Internal>
     </DDSI2Service>
-    <DurabilityService name="durability">
-        <Network>
-            <Alignment>
-                <TimeAlignment>false</TimeAlignment>
-                <RequestCombinePeriod>
-                    <Initial>2.5</Initial>
-                    <Operational>0.1</Operational>
-                </RequestCombinePeriod>
-            </Alignment>
-            <WaitForAttachment maxWaitCount="10">
-                <ServiceName>ddsi2</ServiceName>
-            </WaitForAttachment>
-        </Network>
-        <NameSpaces>
-            <NameSpace name="defaultNamespace">
-                <Partition>*</Partition>
-            </NameSpace>
-            <Policy alignee="Initial" aligner="true" durability="Durable" nameSpace="defaultNamespace"/>
-        </NameSpaces>
-    </DurabilityService>
     <TunerService name="cmsoap">
         <Server>
             <PortNr>Auto</PortNr>

--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(rmw_opensplice_cpp SHARED
   src/rmw_wait.cpp
   src/rmw_waitset.cpp
   src/types.cpp
+  src/misc.cpp
 )
 ament_target_dependencies(rmw_opensplice_cpp
   "rcutils"

--- a/rmw_opensplice_cpp/src/misc.cpp
+++ b/rmw_opensplice_cpp/src/misc.cpp
@@ -1,0 +1,65 @@
+#include <ccpp_dds_dcps.h>
+#include <dds_dcps.h>
+
+#include "rcutils/format_string.h"
+#include "rcutils/types.h"
+#include "rcutils/split.h"
+
+#include "rmw/error_handling.h"
+#include "rmw/rmw.h"
+
+#include "misc.hpp"
+
+static const char * const ros_topic_prefix = "rt";
+
+bool
+process_topic_name(
+  const char * topic_name,
+  bool avoid_ros_namespace_conventions,
+  char ** topic_str,
+  char ** partition_str)
+{
+  bool success = true;
+  rcutils_string_array_t name_tokens = rcutils_get_zero_initialized_string_array();
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (rcutils_split_last(topic_name, '/', allocator, &name_tokens) != RCUTILS_RET_OK) {
+    RMW_SET_ERROR_MSG(rcutils_get_error_string_safe())
+    success = false;
+    goto end;
+  }
+  if (name_tokens.size == 1) {
+    if (!avoid_ros_namespace_conventions) {
+      *partition_str = DDS::string_dup(ros_topic_prefix);
+    }
+    *topic_str = DDS::string_dup(name_tokens.data[0]);
+  } else if (name_tokens.size == 2) {
+    if (avoid_ros_namespace_conventions) {
+      // no ros_topic_prefix, so store the user's namespace directly
+      *partition_str = DDS::string_dup(name_tokens.data[0]);
+    } else {
+      // concat the ros_topic_prefix with the user's namespace
+      char * concat_str =
+        rcutils_format_string(allocator, "%s/%s", ros_topic_prefix, name_tokens.data[0]);
+      if (!concat_str) {
+        RMW_SET_ERROR_MSG("could not allocate memory for partition string")
+        success = false;
+        goto end;
+      }
+      *partition_str = DDS::string_dup(concat_str);
+      allocator.deallocate(concat_str, allocator.state);
+    }
+    *topic_str = DDS::string_dup(name_tokens.data[1]);
+  } else {
+    RMW_SET_ERROR_MSG("incorrectly formatted topic name")
+    success = false;
+  }
+
+end:
+  // all necessary strings are copied into opensplice
+  // free that memory
+  if (rcutils_string_array_fini(&name_tokens) != RCUTILS_RET_OK) {
+    fprintf(stderr, "Failed to destroy the token string array\n");
+  }
+  return success;
+}

--- a/rmw_opensplice_cpp/src/misc.hpp
+++ b/rmw_opensplice_cpp/src/misc.hpp
@@ -1,0 +1,11 @@
+#ifndef MISC_HPP
+#define MISC_HPP_
+
+RMW_LOCAL
+bool process_topic_name(
+  const char * topic_name,
+  bool avoid_ros_namespace_conventions,
+  char ** topic_str,
+  char ** partition_str);
+
+#endif  // MISC_HPP_

--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -143,6 +143,12 @@ rmw_create_node(
   }
 #endif
 
+  // enable the participant, otherwise get_builtin_subscriber can't be called
+  if (participant->enable() != DDS::RETCODE_OK) {
+    RMW_SET_ERROR_MSG("failed to enable domain participant");
+    return nullptr;
+  }
+
   rmw_node_t * node = nullptr;
   OpenSpliceStaticNodeInfo * node_info = nullptr;
   rmw_guard_condition_t * graph_guard_condition = nullptr;
@@ -238,12 +244,6 @@ rmw_create_node(
 
   node->implementation_identifier = opensplice_cpp_identifier;
   node->data = node_info;
-
-  // finally enable the participant
-  if (participant->enable() != DDS::RETCODE_OK) {
-    RMW_SET_ERROR_MSG("failed to enable domain participant");
-    goto fail;
-  }
 
   return node;
 fail:

--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -247,10 +247,8 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
 endif()
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROPERTIES
     COMPILE_FLAGS "-Wall -Wextra -Wpedantic")

--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -31,6 +31,7 @@
 #include "@(spec.base_type.pkg_name)/msg/rosidl_generator_c__visibility_control.h"
 // Provides the definition of the message_type_support_callbacks_t struct.
 #include "rosidl_typesupport_opensplice_cpp/message_type_support.h"
+#include "rosidl_typesupport_opensplice_cpp/u__instanceHandle.h"
 
 #include "@(pkg)/msg/rosidl_typesupport_opensplice_c__visibility_control.h"
 @{header_file_name = get_header_filename_from_msg_name(type)}@

--- a/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
@@ -33,7 +33,9 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
-add_library(${PROJECT_NAME} SHARED src/identifier.cpp)
+add_library(${PROJECT_NAME} SHARED
+  src/identifier.cpp
+  src/u_instanceHandle.c)
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_BUILDING_DLL")

--- a/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_opensplice_cpp/CMakeLists.txt
@@ -44,6 +44,7 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   include
 )
+ament_target_dependencies(${PROJECT_NAME} "OpenSplice")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_typesupport_cpp")

--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -261,10 +261,8 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
 endif()
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PROPERTIES COMPILE_FLAGS "-Wall -Wextra -Wpedantic")

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
@@ -1,0 +1,39 @@
+/*
+ *                         OpenSplice DDS
+ *
+ *   This software and documentation are Copyright 2006 to TO_YEAR PrismTech
+ *   Limited, its affiliated companies and licensors. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#ifndef U__INSTANCEHANDLE_H
+#define U__INSTANCEHANDLE_H
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "u_instanceHandle.h"
+#include "v_collection.h"
+
+v_gid
+u_instanceHandleToGID (
+    u_instanceHandle _this);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
@@ -17,8 +17,8 @@
  *   limitations under the License.
  *
  */
-#ifndef U__INSTANCEHANDLE_H
-#define U__INSTANCEHANDLE_H
+#ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
+#define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
 
 #if __cplusplus
 extern "C"
@@ -30,10 +30,10 @@ extern "C"
 
 v_gid
 u_instanceHandleToGID (
-    u_instanceHandle _this);
+  u_instanceHandle _this);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif  // ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -28,6 +28,7 @@
 #include "rosidl_typesupport_opensplice_cpp/identifier.hpp"
 #include "rosidl_typesupport_opensplice_cpp/message_type_support.h"
 #include "rosidl_typesupport_opensplice_cpp/message_type_support_decl.hpp"
+#include "rosidl_typesupport_opensplice_cpp/u__instanceHandle.h"
 
 // include type support for builtin interfaces
 @{

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -107,9 +107,9 @@ def _copy_constructor_and_assignment_operator(lines, msg_name, idl_path=None):
     for i, line in enumerate(lines):
         if line.strip() == 'public:':
             new_lines = [
-                '%sTypeSupportFactory(const %sTypeSupportFactory & o) = delete;' %
+                '%sTypeSupportMetaHolder(const %sTypeSupportMetaHolder & o) = delete;' %
                 (msg_name, msg_name),
-                '%sTypeSupportFactory & operator=(const %sTypeSupportFactory & o) = delete;' %
+                '%sTypeSupportMetaHolder & operator=(const %sTypeSupportMetaHolder & o) = delete;' %
                 (msg_name, msg_name),
             ]
             lines[i + 1:i + 1] = [' ' * 16 + l for l in new_lines]

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -105,15 +105,16 @@ def _modify(filename, msg_name, callback, idl_path=None):
 
 def _copy_constructor_and_assignment_operator(lines, msg_name, idl_path=None):
     for i, line in enumerate(lines):
-        if line.strip() == 'public:':
-            new_lines = [
-                '%sTypeSupportMetaHolder(const %sTypeSupportMetaHolder & o) = delete;' %
-                (msg_name, msg_name),
-                '%sTypeSupportMetaHolder & operator=(const %sTypeSupportMetaHolder & o) = delete;' %
-                (msg_name, msg_name),
-            ]
-            lines[i + 1:i + 1] = [' ' * 16 + l for l in new_lines]
-            return lines
+        if line.strip() != 'public:':
+            continue
+        new_lines = [
+            '%sTypeSupportMetaHolder(const %sTypeSupportMetaHolder & o) = delete;' %
+            (msg_name, msg_name),
+            '%sTypeSupportMetaHolder & operator=(const %sTypeSupportMetaHolder & o) = delete;' %
+            (msg_name, msg_name),
+        ]
+        lines[i + 1:i + 1] = [' ' * 16 + l for l in new_lines]
+        return lines
     assert False, 'Failed to find insertion point'
 
 

--- a/rosidl_typesupport_opensplice_cpp/src/u_instanceHandle.c
+++ b/rosidl_typesupport_opensplice_cpp/src/u_instanceHandle.c
@@ -1,0 +1,46 @@
+/*
+ *                         OpenSplice DDS
+ *
+ *   This software and documentation are Copyright 2006 to TO_YEAR PrismTech
+ *   Limited, its affiliated companies and licensors. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#include "rosidl_typesupport_opensplice_cpp/u__instanceHandle.h"
+
+#define HANDLE_GLOBAL_MASK (0x80000000)
+
+typedef union {
+    struct {
+        c_ulong lifecycleId;
+        c_ulong localId;
+    } lid;
+    u_instanceHandle handle;
+} u_instanceHandleTranslator;
+
+v_gid
+u_instanceHandleToGID (
+    u_instanceHandle handle)
+{
+    u_instanceHandleTranslator translator;
+    v_gid gid;
+
+    translator.handle = handle;
+
+    gid.systemId = translator.lid.lifecycleId & ~HANDLE_GLOBAL_MASK;
+    gid.localId = translator.lid.localId;
+    gid.serial = 0;
+
+    return gid;
+}

--- a/rosidl_typesupport_opensplice_cpp/src/u_instanceHandle.c
+++ b/rosidl_typesupport_opensplice_cpp/src/u_instanceHandle.c
@@ -22,25 +22,25 @@
 #define HANDLE_GLOBAL_MASK (0x80000000)
 
 typedef union {
-    struct {
-        c_ulong lifecycleId;
-        c_ulong localId;
-    } lid;
-    u_instanceHandle handle;
+  struct {
+    c_ulong lifecycleId;
+    c_ulong localId;
+  } lid;
+  u_instanceHandle handle;
 } u_instanceHandleTranslator;
 
 v_gid
 u_instanceHandleToGID (
-    u_instanceHandle handle)
+  u_instanceHandle handle)
 {
-    u_instanceHandleTranslator translator;
-    v_gid gid;
+  u_instanceHandleTranslator translator;
+  v_gid gid;
 
-    translator.handle = handle;
+  translator.handle = handle;
 
-    gid.systemId = translator.lid.lifecycleId & ~HANDLE_GLOBAL_MASK;
-    gid.localId = translator.lid.localId;
-    gid.serial = 0;
+  gid.systemId = translator.lid.lifecycleId & ~HANDLE_GLOBAL_MASK;
+  gid.localId = translator.lid.localId;
+  gid.serial = 0;
 
-    return gid;
+  return gid;
 }


### PR DESCRIPTION
This is the first step getting the ROS 2 code to compile against OpenSplice 6.7.

The implementation needs to be updated with all the recent changes (partitions, topic prefixes, etc.). So currently many tests are still failing. Also CI is not able to use OpenSplice 6.7 atm.