### PR TITLE
Implement avoid_ros_namespace_conventions

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -58,11 +58,6 @@ rmw_create_client(
     return nullptr;
   }
 
-  if (qos_profile->avoid_ros_namespace_conventions) {
-    RMW_SET_ERROR_MSG("QoS 'avoid_ros_namespace_conventions' is not implemented");
-    return NULL;
-  }
-
   auto node_info = static_cast<OpenSpliceStaticNodeInfo *>(node->data);
   if (!node_info) {
     RMW_SET_ERROR_MSG("node info handle is null");
@@ -112,6 +107,7 @@ rmw_create_client(
     reinterpret_cast<void **>(&response_datareader),
     reinterpret_cast<const void *>(&datareader_qos),
     reinterpret_cast<const void *>(&datawriter_qos),
+    qos_profile->avoid_ros_namespace_conventions,
     &rmw_allocate);
   if (error_string) {
     RMW_SET_ERROR_MSG((std::string("failed to create requester: ") + error_string).c_str());

--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -71,11 +71,6 @@ rmw_create_publisher(
     return nullptr;
   }
 
-  if (qos_profile->avoid_ros_namespace_conventions) {
-    RMW_SET_ERROR_MSG("QoS 'avoid_ros_namespace_conventions' is not implemented");
-    return NULL;
-  }
-
   auto node_info = static_cast<OpenSpliceStaticNodeInfo *>(node->data);
   if (!node_info) {
     RMW_SET_ERROR_MSG("node info handle is null");

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -57,11 +57,6 @@ rmw_create_service(
     return nullptr;
   }
 
-  if (qos_profile->avoid_ros_namespace_conventions) {
-    RMW_SET_ERROR_MSG("QoS 'avoid_ros_namespace_conventions' is not implemented");
-    return NULL;
-  }
-
   auto node_info = static_cast<OpenSpliceStaticNodeInfo *>(node->data);
   if (!node_info) {
     RMW_SET_ERROR_MSG("node info handle is null");
@@ -110,6 +105,7 @@ rmw_create_service(
     reinterpret_cast<void **>(&request_datareader),
     reinterpret_cast<const void *>(&datareader_qos),
     reinterpret_cast<const void *>(&datawriter_qos),
+    qos_profile->avoid_ros_namespace_conventions,
     &rmw_allocate);
   if (error_string) {
     RMW_SET_ERROR_MSG((std::string("failed to create responder: ") + error_string).c_str());

--- a/rmw_opensplice_cpp/src/rmw_subscription.cpp
+++ b/rmw_opensplice_cpp/src/rmw_subscription.cpp
@@ -72,11 +72,6 @@ rmw_create_subscription(
     return nullptr;
   }
 
-  if (qos_profile->avoid_ros_namespace_conventions) {
-    RMW_SET_ERROR_MSG("QoS 'avoid_ros_namespace_conventions' is not implemented");
-    return NULL;
-  }
-
   auto node_info = static_cast<OpenSpliceStaticNodeInfo *>(node->data);
   if (!node_info) {
     RMW_SET_ERROR_MSG("node info handle is null");

--- a/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
@@ -65,6 +65,7 @@ create_requester__@(spec.srv_name)(
   void ** untyped_requester, void ** untyped_reader,
   const void * untyped_datareader_qos,
   const void * untyped_datawriter_qos,
+  bool avoid_ros_namespace_conventions,
   void * (*allocator)(size_t))
 {
   return @(spec.pkg_name)::srv::typesupport_opensplice_cpp::create_requester__@(spec.srv_name)(
@@ -72,6 +73,7 @@ create_requester__@(spec.srv_name)(
     untyped_requester, untyped_reader,
     untyped_datareader_qos,
     untyped_datawriter_qos,
+    avoid_ros_namespace_conventions,
     allocator);
 }
 
@@ -81,6 +83,7 @@ create_responder__@(spec.srv_name)(
   void ** untyped_responder, void ** untyped_reader,
   const void * untyped_datareader_qos,
   const void * untyped_datawriter_qos,
+  bool avoid_ros_namespace_conventions,
   void * (*allocator)(size_t))
 {
   return @(spec.pkg_name)::srv::typesupport_opensplice_cpp::create_responder__@(spec.srv_name)(
@@ -88,6 +91,7 @@ create_responder__@(spec.srv_name)(
     untyped_responder, untyped_reader,
     untyped_datareader_qos,
     untyped_datawriter_qos,
+    avoid_ros_namespace_conventions,
     allocator);
 }
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/misc.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/misc.hpp
@@ -28,6 +28,14 @@ bool process_topic_name(
   std::string & topic_str,
   std::string & partition_str);
 
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
+bool process_service_name(
+  const char * service_name,
+  bool avoid_ros_namespace_conventions,
+  std::string & service_str,
+  std::string & request_partition_str,
+  std::string & response_partition_str);
+
 }  // namespace rosidl_typesupport_opensplice_cpp
 
 #endif  // ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__MISC_HPP_

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -47,35 +47,31 @@ public:
   {}
 
   const char * init(const DDS::DataReaderQos * datareader_qos,
-    const DDS::DataWriterQos * datawriter_qos)
+    const DDS::DataWriterQos * datawriter_qos,
+    bool avoid_ros_namespace_conventions)
   {
     DDS::ReturnCode_t status;
     DDS::TopicQos default_topic_qos;
     DDS::SubscriberQos subscriber_qos;
     DDS::PublisherQos publisher_qos;
+    std::string service_str;
     std::string request_type_name = service_type_name_ + "_Request_";
-    std::string request_topic_name = service_name_ + "_Request";
+    std::string request_topic_name;
+    std::string request_partition_name;
     std::string response_type_name = service_type_name_ + "_Response_";
-    std::string response_topic_name = service_name_ + "_Response";
-    std::string request_topic_str;
-    std::string request_partition_str;
-    std::string response_topic_str;
-    std::string response_partition_str;
+    std::string response_topic_name;
+    std::string response_partition_name;
     const char * estr = nullptr;
 
-    if (!process_topic_name(
-        request_topic_name.c_str(), false, request_topic_str, request_partition_str))
+    if (!process_service_name(
+        service_name_.c_str(), avoid_ros_namespace_conventions, service_str,
+        request_partition_name, response_partition_name))
     {
-      RMW_SET_ERROR_MSG(rcutils_get_error_string_safe());
+      estr = "process_service_name: failed";
       goto fail;
     }
-
-    if (!process_topic_name(
-        response_topic_name.c_str(), false, response_topic_str, response_partition_str))
-    {
-      RMW_SET_ERROR_MSG(rcutils_get_error_string_safe());
-      goto fail;
-    }
+    request_topic_name = service_str + "_Request";
+    response_topic_name = service_str + "_Response";
 
     // Create request Publisher and DataWriter
     status = participant_->get_default_topic_qos(default_topic_qos);
@@ -83,7 +79,7 @@ public:
       goto fail;
     }
     request_topic_ = participant_->create_topic(
-      request_topic_str.c_str(), request_type_name.c_str(), default_topic_qos, NULL,
+      request_topic_name.c_str(), request_type_name.c_str(), default_topic_qos, NULL,
       DDS::STATUS_MASK_NONE);
     if (!request_topic_) {
       estr = "DomainParticipant::create_topic: failed";
@@ -96,9 +92,9 @@ public:
       goto fail;
     }
 
-    if (0 != request_partition_str.size()) {
+    if (0 != request_partition_name.size()) {
       subscriber_qos.partition.name.length(1);
-      subscriber_qos.partition.name[0] = DDS::string_dup(request_partition_str.c_str());
+      subscriber_qos.partition.name[0] = DDS::string_dup(request_partition_name.c_str());
     }
 
     request_subscriber_ = participant_->create_subscriber(
@@ -122,9 +118,9 @@ public:
       goto fail;
     }
 
-    if (0 != response_partition_str.size()) {
+    if (0 != response_partition_name.size()) {
       publisher_qos.partition.name.length(1);
-      publisher_qos.partition.name[0] = DDS::string_dup(response_partition_str.c_str());
+      publisher_qos.partition.name[0] = DDS::string_dup(response_partition_name.c_str());
     }
 
     response_publisher_ = participant_->create_publisher(
@@ -135,7 +131,7 @@ public:
     }
 
     response_topic_ = participant_->create_topic(
-      response_topic_str.c_str(), response_type_name.c_str(), default_topic_qos, NULL,
+      response_topic_name.c_str(), response_type_name.c_str(), default_topic_qos, NULL,
       DDS::STATUS_MASK_NONE);
     if (!response_topic_) {
       estr = "DomainParticipant::create_topic: failed";

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
@@ -31,7 +31,8 @@ typedef struct service_type_support_callbacks_t
   // Passing NULL to the allocator will result in malloc being used.
   const char * (*create_requester)(
     void * participant, const char * service_name, void ** requester, void ** reader,
-    const void * datareader_qos, const void * datawriter_qos, void * (*allocator)(size_t));
+    const void * datareader_qos, const void * datawriter_qos, bool avoid_ros_namespace_conventions,
+    void * (*allocator)(size_t));
   // De-allocate a requester
   // The deallocator should match the allocator passed to create_requester.
   // Returns NULL if the requester was successfully destroyed, otherwise an error string.
@@ -42,7 +43,8 @@ typedef struct service_type_support_callbacks_t
   // Passing NULL to the allocator will result in malloc being used.
   const char * (*create_responder)(
     void * participant, const char * service_name, void ** responder, void ** reader,
-    const void * datareader_qos, const void * datawriter_qos, void * (*allocator)(size_t));
+    const void * datareader_qos, const void * datawriter_qos, bool avoid_ros_namespace_conventions,
+    void * (*allocator)(size_t));
   // De-allocate a responder
   // The deallocator should match the allocator passed to create_respnder.
   // Returns NULL if the responder was successfully destroyed, otherwise an error string.

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
@@ -282,6 +282,7 @@ create_requester__@(spec.srv_name)(
   void ** untyped_requester, void ** untyped_reader,
   const void * untyped_datareader_qos,
   const void * untyped_datawriter_qos,
+  bool avoid_ros_namespace_conventions,
   void * (*allocator)(size_t))
 {
   auto _allocator = allocator ? allocator : &malloc;
@@ -321,7 +322,8 @@ create_requester__@(spec.srv_name)(
     // throw exceptions below.
     return "C++ exception caught during construction of RequesterT";
   }
-  error_string = requester->init(datareader_qos, datawriter_qos);
+  error_string = requester->init(datareader_qos, datawriter_qos,
+      avoid_ros_namespace_conventions);
   if (error_string) {
     return error_string;
   }
@@ -338,6 +340,7 @@ create_responder__@(spec.srv_name)(
   void ** untyped_responder, void ** untyped_reader,
   const void * untyped_datareader_qos,
   const void * untyped_datawriter_qos,
+  bool avoid_ros_namespace_conventions,
   void * (*allocator)(size_t))
 {
   auto _allocator = allocator ? allocator : &malloc;
@@ -377,7 +380,8 @@ create_responder__@(spec.srv_name)(
     // throw exceptions below.
     return "C++ exception caught during construction of ResponderT";
   }
-  error_string = responder->init(datareader_qos, datawriter_qos);
+  error_string = responder->init(datareader_qos, datawriter_qos,
+      avoid_ros_namespace_conventions);
   if (error_string) {
     return error_string;
   }

--- a/rosidl_typesupport_opensplice_cpp/src/misc.cpp
+++ b/rosidl_typesupport_opensplice_cpp/src/misc.cpp
@@ -18,6 +18,8 @@
 namespace rosidl_typesupport_opensplice_cpp
 {
 static const char * const ros_topic_prefix = "rt";
+static const char * const ros_service_request_prefix = "rq";
+static const char * const ros_service_response_prefix = "rr";
 
 bool
 process_topic_name(
@@ -40,6 +42,36 @@ process_topic_name(
   }
   partition_str += topic_name_.substr(0, pos);
   topic_str = topic_name_.substr(pos + 1);
+
+  return true;
+}
+
+bool
+process_service_name(
+  const char * service_name,
+  bool avoid_ros_namespace_conventions,
+  std::string & service_str,
+  std::string & request_partition_str,
+  std::string & response_partition_str)
+{
+  const std::string service_name_ = service_name;
+  size_t pos;
+
+  pos = service_name_.find_last_of('/');
+
+  request_partition_str.clear();
+  response_partition_str.clear();
+  if (!avoid_ros_namespace_conventions) {
+    request_partition_str = ros_service_request_prefix;
+    response_partition_str = ros_service_response_prefix;
+    if (0 != service_name_.substr(0, pos).size()) {
+      request_partition_str += '/';
+      response_partition_str += '/';
+    }
+  }
+  request_partition_str += service_name_.substr(0, pos);
+  response_partition_str += service_name_.substr(0, pos);
+  service_str = service_name_.substr(pos + 1);
 
   return true;
 }


### PR DESCRIPTION
- added new function process_service_name
- remove datawriter&datareader qos from requester/responder signature and replace with rmw_qos_profile_t
- move qos conversion functions from rmw_opensplice to rosidl_typesupport_opensplice_cpp