### PR TITLE
Use matched count to determine server_is_available

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
@@ -62,8 +62,7 @@ rmw_service_server_is_available(
     return RMW_RET_ERROR;
   }
 
-  const char * err = callbacks->server_is_available(
-    client_info->requester_, node, is_available, &rmw_count_publishers, &rmw_count_subscribers);
+  const char * err = callbacks->server_is_available(client_info->requester_, node, is_available);
   if (err) {
     RMW_SET_ERROR_MSG(err);
     return RMW_RET_ERROR;

--- a/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
@@ -231,12 +231,10 @@ destroy_responder__@(spec.srv_name)(void * untyped_responder, void (* deallocato
 
 const char *
 server_is_available__@(spec.srv_name)(
-  void * requester, const rmw_node_t * node, bool * is_available,
-  rmw_ret_t (* count_publishers)(const rmw_node_t *, const char *, size_t *),
-  rmw_ret_t (* count_subscribers)(const rmw_node_t *, const char *, size_t *))
+  void * requester, const rmw_node_t * node, bool * is_available)
 {
   return @(spec.pkg_name)::srv::typesupport_opensplice_cpp::server_is_available__@(spec.srv_name)(
-    requester, node, is_available, count_publishers, count_subscribers);
+    requester, node, is_available);
 }
 
 static service_type_support_callbacks_t __callbacks = {

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/misc.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/misc.hpp
@@ -17,9 +17,13 @@
 
 #include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
 #include <string>
+#include <vector>
 
 namespace rosidl_typesupport_opensplice_cpp
 {
+
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
+const std::vector<std::string> & get_ros_prefixes();
 
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
 bool process_topic_name(

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/service_type_support.h
@@ -70,9 +70,7 @@ typedef struct service_type_support_callbacks_t
   // Returns NULL if the check was successfully, otherwise an error string.
   // If no server is available, NULL is returned but is_available will be set to false.
   const char * (*server_is_available)(
-    void * requester, const rmw_node_t * node, bool * is_available,
-    rmw_ret_t (* count_publishers)(const rmw_node_t *, const char *, size_t *),
-    rmw_ret_t (* count_subscribers)(const rmw_node_t *, const char *, size_t *));
+    void * requester, const rmw_node_t * node, bool * is_available);
 } service_type_support_callbacks_t;
 
 #endif  // ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__SERVICE_TYPE_SUPPORT_H_

--- a/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em
@@ -556,9 +556,7 @@ destroy_responder__@(spec.srv_name)(void * untyped_responder, void (* deallocato
 
 const char *
 server_is_available__@(spec.srv_name)(
-  void * requester, const rmw_node_t * node, bool * is_available,
-  rmw_ret_t (* count_publishers)(const rmw_node_t *, const char *, size_t *),
-  rmw_ret_t (* count_subscribers)(const rmw_node_t *, const char *, size_t *))
+  void * requester, const rmw_node_t * node, bool * is_available)
 {
   using RequesterT = rosidl_typesupport_opensplice_cpp::Requester<
       @(__dds_msg_type_prefix)_Request_,
@@ -567,8 +565,7 @@ server_is_available__@(spec.srv_name)(
 
   auto typed_requester = reinterpret_cast<RequesterT *>(requester);
 
-  return typed_requester->server_is_available(
-    node, is_available, count_publishers, count_subscribers);
+  return typed_requester->server_is_available(node, is_available);
 }
 
 static service_type_support_callbacks_t callbacks = {

--- a/rosidl_typesupport_opensplice_cpp/src/misc.cpp
+++ b/rosidl_typesupport_opensplice_cpp/src/misc.cpp
@@ -13,11 +13,23 @@
 // limitations under the License.
 
 #include <string>
+#include <vector>
 #include "rosidl_typesupport_opensplice_cpp/misc.hpp"
 
 namespace rosidl_typesupport_opensplice_cpp
 {
 static const char * const ros_topic_prefix = "rt";
+static const char * const ros_service_request_prefix = "rq";
+static const char * const ros_service_response_prefix = "rr";
+
+const std::vector<std::string> &
+get_ros_prefixes()
+{
+  static const std::vector<std::string> ros_prefixes =
+  {ros_topic_prefix, ros_service_request_prefix, ros_service_response_prefix};
+
+  return ros_prefixes;
+}
 
 bool
 process_topic_name(


### PR DESCRIPTION
- change the signature of internal server_is_available, removed the count_xxx function pointer
- the server_is_available function now use publication_matched and subscription_matched functions
- DCPSPublication and DCPSSubscription listeners add partition name for discovered topics