### PR TITLE
Fix build issue on windows

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
@@ -20,6 +20,9 @@
 #ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
 #define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
 
+// Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
+#include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
+
 #if __cplusplus
 extern "C"
 {
@@ -28,6 +31,7 @@ extern "C"
 #include "u_instanceHandle.h"  // NOLINT
 #include "v_collection.h"  // NOLINT
 
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
 v_gid
 u_instanceHandleToGID(
   u_instanceHandle _this);

--- a/rosidl_typesupport_opensplice_cpp/resource/visibility_control.h.in
+++ b/rosidl_typesupport_opensplice_cpp/resource/visibility_control.h.in
@@ -1,8 +1,7 @@
 // generated from rosidl_typesupport_opensplice_cpp/resource/visibility_control.h.in
 // generated code does not contain a copyright notice
 
-#ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__VISIBILITY_CONTROL_H_
-#define @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__VISIBILITY_CONTROL_H_
+// NOLINT(build/header_guard)
 
 #if __cplusplus
 extern "C"
@@ -33,5 +32,3 @@ extern "C"
 #if __cplusplus
 }
 #endif
-
-#endif  // @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
export funtion
update visibility template, OpenSplice generated code (idlpp output)
undefs visibility defines. When combining generated type from multiple
input files this leads to compile erros as the required visibility
define is undefined by the first type.