### PR TITLE
fix some memory leaks

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -302,6 +302,9 @@ fail:
     if (node->name) {
       rmw_free(const_cast<char *>(node->name));
     }
+    if (node->namespace_) {
+      rmw_free(const_cast<char *>(node->namespace_));
+    }
     rmw_node_free(node);
   }
   return nullptr;
@@ -383,6 +386,8 @@ rmw_destroy_node(rmw_node_t * node)
   node->data = nullptr;
   rmw_free(const_cast<char *>(node->name));
   node->name = nullptr;
+  rmw_free(const_cast<char *>(node->namespace_));
+  node->namespace_ = nullptr;
   rmw_node_free(node);
   return result;
 }

--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -130,7 +130,7 @@ rmw_create_publisher(
 
   if (0 != partition_str.size()) {  // only set if not empty
     publisher_qos.partition.name.length(1);
-    publisher_qos.partition.name.get_buffer(FALSE)[0] = DDS::string_dup(partition_str.c_str());
+    publisher_qos.partition.name[0] = partition_str.c_str();
   }
 
   dds_publisher = participant->create_publisher(publisher_qos, NULL, DDS::STATUS_MASK_NONE);


### PR DESCRIPTION
This patch fixes some of the memory leaks seen when running the `demo_nodes_cpp` `talker` / `listener`.

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3146)](http://ci.ros2.org/job/ci_linux/3146/)
---

But there seem to be several more - mostly inside OpenSplice, e.g. the following - maybe @michielb-prismtech has an idea if we are using the API wrong anywhere:

The call to `tsMetaHolder->create_datawriter` (https://github.com/osrf/opensplice/blob/0941db497e2952ddf69454442071e92e0e69d942/src/api/dcps/c%2B%2B/common/code/Publisher.cpp#L257) in `Publisher::create_datawriter` allocates memory.

But the corresponding call to `deinit` (https://github.com/osrf/opensplice/blob/0941db497e2952ddf69454442071e92e0e69d942/src/api/dcps/c%2B%2B/common/code/Publisher.cpp#L375) in `Publisher::delete_datawriter` seems to never deallocate the memory hence the leak shown in valgrind:

```
==7156== 352 (248 direct, 104 indirect) bytes in 1 blocks are definitely lost in loss record 402 of 487
==7156==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7156==    by 0xAABBCB4: rcl_interfaces::msg::dds_::ParameterEvent_TypeSupportMetaHolder::create_datawriter() (ParameterEvent_Dcps_impl.cpp:45)
==7156==    by 0x9023E83: DDS::OpenSplice::Publisher::create_datawriter(DDS::Topic*, DDS::DataWriterQos const&, DDS::DataWriterListener*, unsigned int) (Publisher.cpp:257)
==7156==    by 0x821FDBC: rmw_create_publisher (rmw_publisher.cpp:160)
...
```