### PR TITLE
Typesupport cleanup

### DIFF
--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -150,7 +150,10 @@ rosidl_write_generator_arguments(
   OUTPUT_DIR "${_output_path}"
   TEMPLATE_DIR "${rosidl_typesupport_opensplice_c_TEMPLATE_DIR}"
   TARGET_DEPENDENCIES ${target_dependencies}
-  ADDITIONAL_FILES ${_dds_idl_files}
+  ADDITIONAL_FILES
+  ${_dds_idl_files}
+  ${_generated_external_msg_files}
+  ${_generated_external_srv_files}
 )
 
 add_custom_command(

--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -93,23 +93,6 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   endif()
 endforeach()
 
-# If not on Windows, disable some warnings with OpenSplice's generated code
-if(NOT WIN32)
-  set(_opensplice_compile_flags)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(_opensplice_compile_flags
-      "-Wno-unused-but-set-variable"
-    )
-  endif()
-  if(NOT _opensplice_compile_flags STREQUAL "")
-    string(REPLACE ";" " " _opensplice_compile_flags "${_opensplice_compile_flags}")
-    foreach(_gen_file ${_generated_external_msg_files} ${_generated_external_srv_files})
-      set_source_files_properties("${_gen_file}"
-        PROPERTIES COMPILE_FLAGS "${_opensplice_compile_flags}")
-    endforeach()
-  endif()
-endif()
-
 set(_dependency_files "")
 set(_dependencies "")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
@@ -229,9 +212,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   if(
     NOT _generated_msg_files STREQUAL "" OR
-    NOT _generated_external_msg_files STREQUAL "" OR
-    NOT _generated_srv_files STREQUAL "" OR
-    NOT _generated_external_srv_files STREQUAL ""
+    NOT _generated_srv_files STREQUAL ""
   )
     ament_export_include_directories(include)
   endif()
@@ -240,9 +221,7 @@ endif()
 link_directories(${OpenSplice_LIBRARY_DIRS})
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
   ${_generated_msg_files}
-  ${_generated_external_msg_files}
-  ${_generated_srv_files}
-  ${_generated_external_srv_files})
+  ${_generated_srv_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")


### PR DESCRIPTION
Follow up of #192 which fixed the C++ type support to fix a remaining similar issue with the C type support.

The first commit removes the need to compile the source files generated by the C++ type support when building the C type support. The C type support library already links against the C++ type support library.

The second commit fixes the needless reinvocation of the C type support generator. While the `_generated_external_msg_files` and `_generated_external_srv_files` are not being used by the C type support generator they need to be passed as `ADDITIONAL_FILES` to the generator in order to consider their timestamps. Otherwise since they are `DEPENDS` on the custom command they are responsible to retrigger the target over and over again (until the generator has a reason to override the existing files with newer files which have a "new-enough" timestamp).

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3193)](http://ci.ros2.org/job/ci_linux/3193/)