### PR TITLE
Fix build issue on windows

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/u__instanceHandle.h
@@ -20,6 +20,9 @@
 #ifndef ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
 #define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__U__INSTANCEHANDLE_H_
 
+// Provides visibility macros like ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC.
+#include <rosidl_typesupport_opensplice_cpp/visibility_control.h>
+
 #if __cplusplus
 extern "C"
 {
@@ -28,6 +31,7 @@ extern "C"
 #include "u_instanceHandle.h"  // NOLINT
 #include "v_collection.h"  // NOLINT
 
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_PUBLIC
 v_gid
 u_instanceHandleToGID(
   u_instanceHandle _this);


### PR DESCRIPTION
Supersedes #193 since the latest OpenSplice build doesn't `undef` the passed preprocessor definition anymore at the end of a generated message header.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3198)](http://ci.ros2.org/job/ci_linux/3198/)
* Windows (parallel) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows_opensplice67&build=7)](http://ci.ros2.org/job/ci_windows_opensplice67/7/)
* Windows (non-parallel) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows_opensplice67&build=8)](http://ci.ros2.org/job/ci_windows_opensplice67/8/)