### PR TITLE
correct responder/requester topic names

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/requester.hpp
@@ -107,8 +107,8 @@ public:
       estr = "process_service_name: failed";
       goto fail;
     }
-    request_topic_name = service_str + "_Request";
-    response_topic_name = service_str + "_Response";
+    request_topic_name = service_str + "Request";
+    response_topic_name = service_str + "Reply";
     content_filtered_topic_name = service_str +
       std::to_string(writer_guid_.first) + "_" + std::to_string(writer_guid_.second);
 

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/responder.hpp
@@ -70,8 +70,8 @@ public:
       estr = "process_service_name: failed";
       goto fail;
     }
-    request_topic_name = service_str + "_Request";
-    response_topic_name = service_str + "_Response";
+    request_topic_name = service_str + "Request";
+    response_topic_name = service_str + "Reply";
 
     // Create request Publisher and DataWriter
     status = participant_->get_default_topic_qos(default_topic_qos);


### PR DESCRIPTION
During running the checklist we found that the topic names for the requester and responder did not match with fastRTPS implementation