### PR TITLE
Fix rmw_opensplice dead code

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -193,9 +193,6 @@ rmw_create_publisher(
 
   return publisher;
 fail:
-  if (publisher) {
-    rmw_publisher_free(publisher);
-  }
   if (dds_publisher) {
     if (topic_writer) {
       status = dds_publisher->delete_datawriter(topic_writer);

--- a/rmw_opensplice_cpp/src/rmw_subscription.cpp
+++ b/rmw_opensplice_cpp/src/rmw_subscription.cpp
@@ -226,9 +226,7 @@ fail:
   if (subscriber_info) {
     rmw_free(subscriber_info);
   }
-  if (subscription) {
-    rmw_subscription_free(subscription);
-  }
+
   if (buf) {
     rmw_free(buf);
   }


### PR DESCRIPTION
Dead code in API `rmw_create_subscription()`
the condition "`subscription`" cannot be true in the "`fail`"
clauses and the execution never reaches this statement:

```
if (subscription) {
    rmw_subscription_free(subscription);
  }
```

the "`subscribtion`" will be finally free by
`rmw_destroy_subscription() `when it's not a nullptr

Dead code in API `rmw_create_publisher()`
the condition "`publisher`" cannot be true in the "`fail`"
clauses, so the execution cannot reach this statement:

```
if (publisher) {
    rmw_publisher_free(publisher);
  }
```

the "`publisher`" will be finally free by
`rmw_destroy_publisher()` when it's not a nullptr

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>