### PR TITLE
export / use typesupport libraries separately

### DIFF
--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -243,6 +243,8 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
 add_dependencies(
@@ -262,7 +264,8 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     RUNTIME DESTINATION bin
   )
 
-  ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  rosidl_export_typesupport_libraries(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -264,6 +264,8 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
 add_dependencies(
@@ -283,7 +285,8 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     RUNTIME DESTINATION bin
   )
 
-  ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  rosidl_export_typesupport_libraries(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)


### PR DESCRIPTION
Export the typesupport libraries in a separate CMake variable. The typesupport libraries of one package then need to additionally link against the separate CMake variable of other message packages.

Connect to ros2/rosidl#284.