### PR TITLE
Export OSPL_HOME in env hook

### DIFF
--- a/opensplice_cmake_module/env_hook/opensplice.bat.in
+++ b/opensplice_cmake_module/env_hook/opensplice.bat.in
@@ -46,6 +46,8 @@ set OSPL_VERBOSITY=2
 :: This is required because rmw_opensplice_cpp cannot work unless it is set.
 if "%ROS_DOMAIN_ID%"=="" set ROS_DOMAIN_ID=0
 
+set "OSPL_HOME=%_OSPL_HOME_TO_USE%"
+
 set "_BUILDTIME_OSPL_HOME="
 set "_OSPL_HOME_TO_USE="
 set "_OSPL_ENV_SETUP_SCRIPT="

--- a/opensplice_cmake_module/env_hook/opensplice.sh.in
+++ b/opensplice_cmake_module/env_hook/opensplice.sh.in
@@ -71,6 +71,8 @@ elif [ "$OSPL_URI" != "$_DEFAULT_OSPL_URI" ]; then
   echo "[opensplice_cmake_module] Warning: OSPL_URI was already set to [[$OSPL_URI]]. This will not override it to the ROS default [[$_DEFAULT_OSPL_URI]]. Please make sure this is the config that you want." 1>&2
 fi
 
+export OSPL_HOME="$_OSPL_HOME_TO_USE"
+
 unset _DEFAULT_OSPL_URI
 unset _BUILDTIME_OSPL_HOME
 unset _OSPL_HOME_TO_USE


### PR DESCRIPTION
This was an unintended side effect of https://github.com/ros2/rmw_opensplice/pull/219

Opensplice (at least on linux) will output an error if you don't have the OSPL_HOME env var set:
```
========================================================================================
Report      : ERROR
Date        : Wed Jun 20 16:55:54 PDT 2018
Description : OSPL_HOME is not set
Node        : osrf-esteve
Process     : talker <16979>
Thread      : spliced 7fe6e4ab0700
Internals   : 6.7.180404OSS///configuration validator/cfg_validator.c/830/0/1529538954.753761508/-1
```

The testing of https://github.com/ros2/rmw_opensplice/pull/219 was mostly done with packaging jobs, where setting OSPL_HOME is a requirement to get it to work correctly. However, for users who have built a workspace from source with opensplice support, then they try to use that workspace in another terminal, ordinarily we don't required them to set OSPL_HOME. We used to export it for them in the env hook, but that changed in https://github.com/ros2/rmw_opensplice/pull/219 (intentionally, but with unintentional side effects).