### PR TITLE
strip 'Sample_' from reported types

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_service_names_and_types.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service_names_and_types.cpp
@@ -30,6 +30,7 @@
 #include "types.hpp"
 #include "demangle.hpp"
 
+#define SAMPLE_PREFIX "/Sample_"
 // The extern "C" here enforces that overloading is not used.
 extern "C"
 {
@@ -119,7 +120,13 @@ rmw_get_service_names_and_types(
       // Duplicate and store each type for the service
       size_t type_index = 0;
       for (const auto & type : service_n_types.second) {
-        char * type_name = rcutils_strdup(type.c_str(), *allocator);
+        size_t n = type.find(SAMPLE_PREFIX);
+        std::string stripped_type = type;
+        if (n < type.size() - strlen(SAMPLE_PREFIX)) {
+          stripped_type = std::string(type.substr(0, n + 1).c_str()) + \
+            std::string(type.substr(n + strlen(SAMPLE_PREFIX)).c_str());
+        }
+        char * type_name = rcutils_strdup(stripped_type.c_str(), *allocator);
         if (!type_name) {
           RMW_SET_ERROR_MSG_ALLOC("failed to allocate memory for type name", *allocator)
           fail_cleanup();


### PR DESCRIPTION
Opening this for visibility.
I didn't see anywhere the `Sample_` prefix was defined so I ended up hard-coding it in here for now.

Feedback on the approach is welcome.

Connects to ros2/ros2cli#106