### PR TITLE
accept RETCODE_PRECONDITION_NOT_MET when detaching condition

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -278,7 +278,8 @@ rmw_wait(
         // reset the subscriber handle
         subscriptions->subscribers[i] = 0;
       }
-      if (dds_wait_set->detach_condition(read_condition) != DDS::RETCODE_OK) {
+      DDS::ReturnCode_t detach_status = dds_wait_set->detach_condition(read_condition);
+      if (detach_status != DDS::RETCODE_OK && detach_status != DDS::RETCODE_PRECONDITION_NOT_MET) {
         RMW_SET_ERROR_MSG("failed to detach guard condition");
         return RMW_RET_ERROR;
       }

--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -371,7 +371,8 @@ rmw_wait(
       if (!(j < active_conditions->length())) {
         clients->clients[i] = 0;
       }
-      if (dds_wait_set->detach_condition(read_condition) != DDS::RETCODE_OK) {
+      DDS::ReturnCode_t detach_status = dds_wait_set->detach_condition(read_condition);
+      if (detach_status != DDS::RETCODE_OK && detach_status != DDS::RETCODE_PRECONDITION_NOT_MET) {
         RMW_SET_ERROR_MSG("failed to detach guard condition");
         return RMW_RET_ERROR;
       }


### PR DESCRIPTION
Possible work around for ros2/ros2cli#107. I am just not fully convinced that it is the right thing to do...