### PR TITLE
Add semicolons to all RCLCPP and RCUTILS macros.

### DIFF
--- a/rmw_opensplice_cpp/src/demangle.cpp
+++ b/rmw_opensplice_cpp/src/demangle.cpp
@@ -85,7 +85,7 @@ _demangle_service_from_topic(const std::string & topic_name)
       if (topic_name.length() - suffix_position - suffix.length() != 0) {
         RCUTILS_LOG_WARN_NAMED("rmw_opensplice_cpp",
           "service topic has service prefix and a suffix, but not at the end"
-          ", report this: '%s'", topic_name.c_str())
+          ", report this: '%s'", topic_name.c_str());
         continue;
       }
       found_suffix = suffix;
@@ -95,7 +95,7 @@ _demangle_service_from_topic(const std::string & topic_name)
   if (suffix_position == std::string::npos) {
     RCUTILS_LOG_WARN_NAMED("rmw_opensplice_cpp",
       "service topic has prefix but no suffix"
-      ", report this: '%s'", topic_name.c_str())
+      ", report this: '%s'", topic_name.c_str());
     return "";
   }
   // strip off the suffix first
@@ -126,7 +126,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
       if (dds_type_name.length() - suffix_position - suffix.length() != 0) {
         RCUTILS_LOG_WARN_NAMED("rmw_opensplice_cpp",
           "service type contains '::srv::dds_::' and a suffix, but not at the end"
-          ", report this: '%s'", dds_type_name.c_str())
+          ", report this: '%s'", dds_type_name.c_str());
         continue;
       }
       found_suffix = suffix;
@@ -136,7 +136,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
   if (suffix_position == std::string::npos) {
     RCUTILS_LOG_WARN_NAMED("rmw_opensplice_cpp",
       "service type contains '::srv::dds_::' but does not have a suffix"
-      ", report this: '%s'", dds_type_name.c_str())
+      ", report this: '%s'", dds_type_name.c_str());
     return "";
   }
   // everything checks out, reformat it from '<pkg>::srv::dds_::<type><suffix>' to '<pkg>/<type>'

--- a/rmw_opensplice_cpp/src/rmw_node_names.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node_names.cpp
@@ -168,28 +168,28 @@ fail:
   if (rcutils_ret != RCUTILS_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_opensplice_cpp",
-      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
     rcutils_reset_error();
   }
   rcutils_ret = rcutils_string_array_fini(&node_list);
   if (rcutils_ret != RCUTILS_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_opensplice_cpp",
-      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
     rcutils_reset_error();
   }
   rcutils_ret = rcutils_string_array_fini(node_names);
   if (rcutils_ret != RCUTILS_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_opensplice_cpp",
-      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
     rcutils_reset_error();
   }
   rcutils_ret = rcutils_string_array_fini(node_namespaces);
   if (rcutils_ret != RCUTILS_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_opensplice_cpp",
-      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+      "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
     rcutils_reset_error();
   }
   return RMW_RET_BAD_ALLOC;

--- a/rmw_opensplice_cpp/src/rmw_service_names_and_types.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service_names_and_types.cpp
@@ -91,7 +91,7 @@ rmw_get_service_names_and_types(
     auto fail_cleanup = [&service_names_and_types]() {
         rmw_ret_t rmw_ret = rmw_names_and_types_fini(service_names_and_types);
         if (rmw_ret != RMW_RET_OK) {
-          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe())
+          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // For each service, store the name, initialize the string array for types, and store all types

--- a/rmw_opensplice_cpp/src/rmw_topic_names_and_types.cpp
+++ b/rmw_opensplice_cpp/src/rmw_topic_names_and_types.cpp
@@ -87,7 +87,7 @@ rmw_get_topic_names_and_types(
     auto fail_cleanup = [&topic_names_and_types]() {
         rmw_ret_t rmw_ret = rmw_names_and_types_fini(topic_names_and_types);
         if (rmw_ret != RMW_RET_OK) {
-          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe())
+          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // Setup demangling functions based on no_demangle option


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/rcutils/issues/113