### PR TITLE
suppress warning on Windows

### DIFF
--- a/rmw_opensplice_cpp/src/qos.hpp
+++ b/rmw_opensplice_cpp/src/qos.hpp
@@ -15,23 +15,23 @@
 #ifndef QOS_HPP_
 #define QOS_HPP_
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
 #include <u_instanceHandle.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/rmw.h"
 

--- a/rmw_opensplice_cpp/src/qos.hpp
+++ b/rmw_opensplice_cpp/src/qos.hpp
@@ -15,6 +15,10 @@
 #ifndef QOS_HPP_
 #define QOS_HPP_
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -25,6 +29,9 @@
 #endif
 #include <dds_dcps.h>
 #include <u_instanceHandle.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/rmw.h"
 

--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_client.cpp
+++ b/rmw_opensplice_cpp/src/rmw_client.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_opensplice_cpp/src/rmw_guard_condition.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_opensplice_cpp/src/rmw_guard_condition.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_init.cpp
+++ b/rmw_opensplice_cpp/src/rmw_init.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_opensplice_cpp/src/rmw_init.cpp
+++ b/rmw_opensplice_cpp/src/rmw_init.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_node.cpp
+++ b/rmw_opensplice_cpp/src/rmw_node.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_service.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_opensplice_cpp/src/rmw_service_server_is_available.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_subscription.cpp
+++ b/rmw_opensplice_cpp/src/rmw_subscription.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_subscription.cpp
+++ b/rmw_opensplice_cpp/src/rmw_subscription.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #include <string>
 
 #include "rosidl_typesupport_opensplice_c/identifier.h"

--- a/rmw_opensplice_cpp/src/rmw_trigger_guard_condition.cpp
+++ b/rmw_opensplice_cpp/src/rmw_trigger_guard_condition.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_trigger_guard_condition.cpp
+++ b/rmw_opensplice_cpp/src/rmw_trigger_guard_condition.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_wait.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_wait_set.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait_set.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -21,6 +25,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/rmw_wait_set.cpp
+++ b/rmw_opensplice_cpp/src/rmw_wait_set.cpp
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw_opensplice_cpp/src/types.hpp
+++ b/rmw_opensplice_cpp/src/types.hpp
@@ -15,22 +15,22 @@
 #ifndef TYPES_HPP_
 #define TYPES_HPP_
 
-#if defined(_MSC_VER)
-# pragma warning(push)
-# pragma warning(disable: 4099)
-#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
 #endif
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #include <ccpp_dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
-#if defined(_MSC_VER)
-# pragma warning(pop)
-#endif
 
 #include <list>
 #include <map>

--- a/rmw_opensplice_cpp/src/types.hpp
+++ b/rmw_opensplice_cpp/src/types.hpp
@@ -15,6 +15,10 @@
 #ifndef TYPES_HPP_
 #define TYPES_HPP_
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4099)
+#endif
 #ifdef __clang__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wmismatched-tags"
@@ -24,6 +28,9 @@
 # pragma GCC diagnostic pop
 #endif
 #include <dds_dcps.h>
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 #include <list>
 #include <map>


### PR DESCRIPTION
Follow up of #249.

Almost green Windows build including the external `cdr_serialization` branches: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5564)](https://ci.ros2.org/job/ci_windows/5564/)