### PR TITLE
Add rmw includes to cppcheck

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -103,6 +103,7 @@ register_rmw_implementation(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rmw_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
 endif()
 


### PR DESCRIPTION
Fix cppcheck error complaining about unknown macro (context https://github.com/ament/ament_lint/pull/117#discussion_r261690823)

connects to ros2/rmw_connext#348