### PR TITLE
fix windows build warnings

### DIFF
--- a/rmw_opensplice_cpp/src/qos.cpp
+++ b/rmw_opensplice_cpp/src/qos.cpp
@@ -22,6 +22,21 @@
 using rosidl_typesupport_opensplice_cpp::impl::check_get_default_datareader_qos;
 using rosidl_typesupport_opensplice_cpp::impl::check_get_default_datawriter_qos;
 
+static bool
+is_time_default(const rmw_time_t & time)
+{
+  return time.sec == 0 && time.nsec == 0;
+}
+
+static DDS::Duration_t
+rmw_time_to_dds(const rmw_time_t & time)
+{
+  DDS::Duration_t duration;
+  duration.sec = static_cast<DDS::Long>(time.sec);
+  duration.nanosec = static_cast<DDS::ULong>(time.nsec);
+  return duration;
+}
+
 template<typename DDSEntityQos>
 bool set_entity_qos_from_profile_generic(
   const rmw_qos_profile_t & qos_profile,
@@ -75,9 +90,8 @@ bool set_entity_qos_from_profile_generic(
   }
 
   // DDS_DeadlineQosPolicy has default value of DDS_DURATION_INFINITE, don't touch it for 0
-  if (qos_profile.deadline.sec != 0 || qos_profile.deadline.nsec != 0) {
-    entity_qos.deadline.period.sec = qos_profile.deadline.sec;
-    entity_qos.deadline.period.nanosec = qos_profile.deadline.nsec;
+  if (!is_time_default(qos_profile.deadline)) {
+    entity_qos.deadline.period = rmw_time_to_dds(qos_profile.deadline);
   }
 
   switch (qos_profile.liveliness) {
@@ -96,11 +110,8 @@ bool set_entity_qos_from_profile_generic(
       RMW_SET_ERROR_MSG("Unknown QoS liveliness policy");
       return false;
   }
-  if (qos_profile.liveliness_lease_duration.sec != 0 ||
-    qos_profile.liveliness_lease_duration.nsec != 0)
-  {
-    entity_qos.liveliness.lease_duration.sec = qos_profile.liveliness_lease_duration.sec;
-    entity_qos.liveliness.lease_duration.nanosec = qos_profile.liveliness_lease_duration.nsec;
+  if (!is_time_default(qos_profile.liveliness_lease_duration)) {
+    entity_qos.liveliness.lease_duration = rmw_time_to_dds(qos_profile.liveliness_lease_duration);
   }
 
   // ensure the history depth is at least the requested queue size
@@ -135,9 +146,8 @@ set_entity_qos_from_profile(
   DDS::DataWriterQos & entity_qos)
 {
   // Set any QoS settings that are specific to DataWriter, then call the shared version
-  if (qos_profile.lifespan.sec != 0 || qos_profile.lifespan.nsec != 0) {
-    entity_qos.lifespan.duration.sec = qos_profile.lifespan.sec;
-    entity_qos.lifespan.duration.nanosec = qos_profile.lifespan.nsec;
+  if (!is_time_default(qos_profile.lifespan)) {
+    entity_qos.lifespan.duration = rmw_time_to_dds(qos_profile.lifespan);
   }
   return set_entity_qos_from_profile_generic(qos_profile, entity_qos);
 }


### PR DESCRIPTION
This PR fixes the compiler warnings that showed up on the Windows build (issue brought up at https://github.com/ros2/rmw_opensplice/pull/266#issuecomment-489882495).