### PR TITLE
get_actual_qos() is not setting all of rmw_qos_profile_t

### DIFF
--- a/rmw_opensplice_cpp/src/rmw_publisher.cpp
+++ b/rmw_opensplice_cpp/src/rmw_publisher.cpp
@@ -348,6 +348,7 @@ rmw_publisher_get_actual_qos(
     RMW_SET_ERROR_MSG("publisher internal dds publisher is invalid");
     return RMW_RET_ERROR;
   }
+
   switch (dds_qos.history.kind) {
     case DDS::KEEP_LAST_HISTORY_QOS:
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
@@ -359,17 +360,8 @@ rmw_publisher_get_actual_qos(
       qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
       break;
   }
-  switch (dds_qos.durability.kind) {
-    case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-      break;
-    case DDS::VOLATILE_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-      break;
-    default:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
-      break;
-  }
+  qos->depth = static_cast<size_t>(dds_qos.history.depth);
+
   switch (dds_qos.reliability.kind) {
     case DDS::BEST_EFFORT_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -381,7 +373,41 @@ rmw_publisher_get_actual_qos(
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
       break;
   }
-  qos->depth = static_cast<size_t>(dds_qos.history.depth);
+
+  switch (dds_qos.durability.kind) {
+    case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+      break;
+    case DDS::VOLATILE_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+      break;
+    default:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+      break;
+  }
+
+  qos->deadline.sec = dds_qos.deadline.period.sec;
+  qos->deadline.nsec = dds_qos.deadline.period.nanosec;
+
+  qos->lifespan.sec = dds_qos.lifespan.duration.sec;
+  qos->lifespan.nsec = dds_qos.lifespan.duration.nanosec;
+
+  switch (dds_qos.liveliness.kind) {
+    case DDS::AUTOMATIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+      break;
+    case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
+      break;
+    case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+      break;
+    default:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+      break;
+  }
+  qos->liveliness_lease_duration.sec = dds_qos.liveliness.lease_duration.sec;
+  qos->liveliness_lease_duration.nsec = dds_qos.liveliness.lease_duration.nanosec;
 
   return RMW_RET_OK;
 }


### PR DESCRIPTION
The current implementation of `get_actual_qos()` is not setting/output the values for lifespan, deadline, and liveliness QoS policies.

Depends on https://github.com/ros2/rmw/pull/175.