### PR TITLE
Fix a comparison with a sign mismatch

### DIFF
--- a/rmw_opensplice_cpp/src/qos.cpp
+++ b/rmw_opensplice_cpp/src/qos.cpp
@@ -120,7 +120,7 @@ bool set_entity_qos_from_profile_generic(
     entity_qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS &&
     static_cast<size_t>(entity_qos.history.depth) < qos_profile.depth)
   {
-    if (qos_profile.depth > (std::numeric_limits<DDS::Long>::max)()) {
+    if (qos_profile.depth > static_cast<size_t>((std::numeric_limits<DDS::Long>::max)())) {
       RMW_SET_ERROR_MSG(
         "failed to set history depth since the requested queue size exceeds the DDS type");
       return false;


### PR DESCRIPTION
Resolves build warning due to `-Wsign-compare` with GCC 9.