### PR TITLE
Don't export rcpputils dependency

### DIFF
--- a/rmw_opensplice_cpp/CMakeLists.txt
+++ b/rmw_opensplice_cpp/CMakeLists.txt
@@ -35,7 +35,6 @@ find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
 ament_export_dependencies(
-  rcpputils
   rcutils
   rmw
   rosidl_generator_c


### PR DESCRIPTION
It is not necessary.

It was introduced in #272.