### PR TITLE
Add transient settings to Topic QoS (#295).

### DIFF
--- a/rmw_opensplice_cpp/src/qos.hpp
+++ b/rmw_opensplice_cpp/src/qos.hpp
@@ -49,6 +49,13 @@ get_datawriter_qos(
   const rmw_qos_profile_t & qos_profile,
   DDS::DataWriterQos & datawriter_qos);
 
+RMW_LOCAL
+bool
+get_topic_qos(
+  DDS::DomainParticipant & participant,
+  const rmw_qos_profile_t & qos_profile,
+  DDS::TopicQos & topic_qos);
+
 template<typename AttributeT>
 void
 dds_qos_to_rmw_qos(


### PR DESCRIPTION
When data should be transient, the Topic QoS should reflect that.
Not only does the Durability need to be set, but also the DurabilityService policy.

See for more info #295.